### PR TITLE
[update] remove Networking category

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -5,7 +5,7 @@
 |       Author | <A list of the authors' real names or aliases, plus their GitHub usernames and/or email addresses (in escaped angle brackets)> |
 |       Editor | <Leave this blank; it will be assigned by a SIP Editor> |
 |         Type | <Standard, Process, Informational> |
-|     Category | <Optional, only needed for Type=Standard; Core, Networking, Interface, Framework, Application> |
+|     Category | <Optional, only needed for Type=Standard; Core, Interface, Framework, Application> |
 |      Created | <Date created, in ISO 8601 format (YYYY-MM-DD)> |
 | Comments-URI | <Leave this blank; it will be assigned by a SIP Editor> |
 |       Status | <Leave this blank; it will be assigned by a SIP Editor> |

--- a/sips/sip-1.md
+++ b/sips/sip-1.md
@@ -37,9 +37,7 @@ A SIP category must be specified when the [SIP type](#sip-type) is `Standard`, b
 
 There are five categories of SIP:
 
-1. **Core**: Changes or additions to core features of Sui, including consensus, execution, storage, and account signatures
-
-1. **Networking**: Changes or additions to Sui's mempool or network protocols
+1. **Core**: Changes or additions to core features of Sui, including consensus, execution, networking, storage, and account signatures
 
 1. **Interface**: Changes or additions to RPC specifications or lower-level naming conventions
 


### PR DESCRIPTION
I believe the `Networking` category is tightly coupled with the `Core` category, and it doesn't seem useful to list it separately.