### PR TITLE
SIP: Attestation registry

### DIFF
--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -1,0 +1,67 @@
+|   SIP-Number |  |
+|         ---: | :--- |
+|        Title | Attestation registry |
+|  Description | Open standard for attesters to share signals about packages or modules |
+|       Author | Sidestream Labs https://labs.sidestream.tech |
+|       Editor |  |
+|         Type | Informational |
+|      Created | 2025-02-17 |
+| Comments-URI |  |
+|       Status |  |
+|     Requires | N/A |
+
+## Abstract
+
+Open standard for attesters to share signals about packages or modules.
+
+## Motivation
+
+Currently, there is no straightforward way for the users to ensure safety of a particular package they plan to interact with. This document proposes to create a central registry that will allow:
+    1. Security professionals to provide various attestations for packages or modules
+    2. Regular Sui users to easily discover relevant attestations for a specific package
+
+## Specification
+
+We propose to develop and deploy an official Sui/Move package with:
+- A permissionless "attestation type" registry. It will allow anyone to create new discoverable attestation types.
+    - Once created, the attestation will be frozen
+    - Each attestation type will have required base qualities
+        - `id` — UID of the attestation type
+        - `type_name` — `type_name<T>()` of the `attestation.data` type (enforced to be unique)
+        - `is_revocable` — whether or not the attestations of this type can be revoked
+        - `display_fields` — fields used to create `sui::display::Display` object
+        - `display_values` — values used to create `sui::display::Display` object
+    - Each attestation type can introduce a custom arbitrary logic implemented in an external module that defines `<T>` type (for example, the whitelisting logic of who can issue attestations can be implemented this way)
+    - Creation will emit event with `id`, `type_name` and `is_revocable`
+    - The sender would be required to create Display type for their attestation type
+    - Created Display type will be immutable to prevent misleading updates or renames
+- A permissionless attestation registry. It will allow anyone to create new attestations using any existing attestation types
+   - Once created, the attestation can not be transferred or deleted
+   - Each attestation will have obligatory set of fields
+       - `id` — UID of the attestation
+       - `sender` — the address who created the attestation
+       - `data` — the extra fields stored in the specific “attestation type”
+   - Created attestation will be transferred to the attested package or module
+   - Creation will emit `Attest` event with `id`, `type_name` and `attested` fields
+   - Revoking attestations will be possible by their `sender`s, unless the attestation type is explicitly created as irrevocable
+      - Revocation will update a table with revoked attestation ids used as keys
+	- Revocation will emit `Revoke` event with `id`, `type_name` and `attested` fields
+- A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
+
+## Rationale
+
+The main target of this proposed standard is the end user interacting with packages and modules on Sui blockchain. Therefore, explorers and wallets should be able to index created attestations and provide contextual information to the users.
+
+We wish to enable the Sui community to define exact attestation types suitable for their needs, therefore the proposal makes attestations and attestation types fully permissionless and extensible. Although we would also plan to define first attestation types and provide intended example usage for common use-cases like security audits.
+
+## Backwards Compatibility
+
+There are no issues with backwards compatibility, as this proposal focuses on establishing a new standard.
+
+## Reference Implementation
+
+To be provided by Sidestream Labs.
+
+## Security Considerations
+
+As the ownership of the Attestation objects will be used as a way to define “attested” address, transferability of the Attestation objects should be restricted and stay restricted. Likely the package upgradability will need to be sacrificed to avoid possibility of its misuse.

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -45,7 +45,7 @@ We propose to develop and deploy an official Sui/Move package with:
    - Revoking attestations will be possible by their `sender`s, unless the attestation type is explicitly created as irrevocable
       - Revocation will update a table with revoked attestation ids used as keys
 	- Revocation will emit `Revoke` event with `id`, `type_name` and `attested` fields
-- A per-sender list of trusted attestation types. It will allow known entities (like the package publisher) to recommend specific types reviewed and approved by the community.
+- A per-sender list of trusted attestation types. It will allow known entities to recommend specific types reviewed and approved by the community.
 - A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
 
 ## Rationale

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -46,6 +46,7 @@ We propose to develop and deploy an official Sui/Move package with:
    - Revoking attestations will be possible by their `sender`s, unless the attestation type is explicitly created as irrevocable
       - Revocation will update a table with revoked attestation ids used as keys
 	- Revocation will emit `Revoke` event with `id`, `type_name` and `attested` fields
+- A per-sender list of trusted attestation types. It will allow known entities (like the package publisher) to recommend specific types reviewed and approved by the community.
 - A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
 
 ## Rationale

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -30,8 +30,6 @@ We propose to develop and deploy an official Sui/Move package with:
         - `type_name` — `std::type_name::get<T>()` of the `attestation.data` type
             - Enforced to be unique to prevent two attestation types with the same `type_name`
         - `is_revocable` — whether or not the attestations of this type can be revoked
-        - `display_fields` — fields used to create `sui::display::Display` object
-        - `display_values` — values used to create `sui::display::Display` object
     - Each attestation type can introduce a custom arbitrary logic implemented in an external module that defines `<T>` type (for example, the whitelisting logic of who can issue attestations can be implemented this way)
     - Creation will emit event with `id`, `type_name` and `is_revocable`
     - The sender would be required to create Display type for their attestation type

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -55,7 +55,8 @@ There are no issues with backwards compatibility, as this proposal focuses on es
 
 ## Reference Implementation
 
-To be provided by Sidestream Labs.
+Is developed by Sidestream Labs in [sidestream-tech/sui-attestation-registry](https://github.com/sidestream-tech/sui-attestation-registry).
+
 
 ## Security Considerations
 

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -23,7 +23,7 @@ Currently, there is no straightforward way for the users to ensure safety of a p
 ## Specification
 
 We propose to develop and deploy an official Sui/Move package with:
-- A permissionless "attestation type" registry. It will allow anyone to create new discoverable attestation types.
+- A permissionless "attestation type" registry. It will allow anyone to create new discoverable attestation types
     - Once created, the attestation will be frozen
     - Each attestation type will have required base qualities
         - `id` — UID of the attestation type
@@ -42,8 +42,6 @@ We propose to develop and deploy an official Sui/Move package with:
        - `data` — the extra fields stored in the specific “attestation type”
    - Created attestation will be transferred to the attested package or module
    - Attestation creation function will return `RevokeCap` object, which can be used to revoke original attestation
-- A per-sender list of trusted attestation types. It will allow known entities to recommend specific types reviewed and approved by the community.
-- A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
 
 ## Rationale
 

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -29,7 +29,6 @@ We propose to develop and deploy an official Sui/Move package with:
         - `id` — UID of the attestation type
         - `type_name` — `std::type_name::get<T>()` of the `attestation.data` type
             - Enforced to be unique to prevent two attestation types with the same `type_name`
-        - `is_revocable` — whether or not the attestations of this type can be revoked
     - Each attestation type can introduce a custom arbitrary logic implemented in an external module that defines `<T>` type (for example, the whitelisting logic of who can issue attestations can be implemented this way)
     - The sender would be required to create Display type for their attestation type
     - Created Display type will be immutable to prevent misleading updates or renames

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -27,7 +27,8 @@ We propose to develop and deploy an official Sui/Move package with:
     - Once created, the attestation will be frozen
     - Each attestation type will have required base qualities
         - `id` — UID of the attestation type
-        - `type_name` — `type_name<T>()` of the `attestation.data` type (enforced to be unique)
+        - `type_name` — `std::type_name::get<T>()` of the `attestation.data` type
+            - Enforced to be unique to prevent two attestation types with the same `type_name`
         - `is_revocable` — whether or not the attestations of this type can be revoked
         - `display_fields` — fields used to create `sui::display::Display` object
         - `display_values` — values used to create `sui::display::Display` object

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -31,20 +31,17 @@ We propose to develop and deploy an official Sui/Move package with:
             - Enforced to be unique to prevent two attestation types with the same `type_name`
         - `is_revocable` — whether or not the attestations of this type can be revoked
     - Each attestation type can introduce a custom arbitrary logic implemented in an external module that defines `<T>` type (for example, the whitelisting logic of who can issue attestations can be implemented this way)
-    - Creation will emit event with `id`, `type_name` and `is_revocable`
     - The sender would be required to create Display type for their attestation type
     - Created Display type will be immutable to prevent misleading updates or renames
 - A permissionless attestation registry. It will allow anyone to create new attestations using any existing attestation types
    - Once created, the attestation can not be transferred or deleted
    - Each attestation will have obligatory set of fields
        - `id` — UID of the attestation
-       - `sender` — the address who created the attestation
+       - `receiver` – the address which is being attested
+       - `created_by` — the address who created the attestation
        - `data` — the extra fields stored in the specific “attestation type”
    - Created attestation will be transferred to the attested package or module
-   - Creation will emit `Attest` event with `id`, `type_name` and `attested` fields
-   - Revoking attestations will be possible by their `sender`s, unless the attestation type is explicitly created as irrevocable
-      - Revocation will update a table with revoked attestation ids used as keys
-	- Revocation will emit `Revoke` event with `id`, `type_name` and `attested` fields
+   - Revoking attestations will be possible by the same sender as original `created_by`, unless the attestation type is explicitly created as irrevocable
 - A per-sender list of trusted attestation types. It will allow known entities to recommend specific types reviewed and approved by the community.
 - A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
 

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -41,7 +41,7 @@ We propose to develop and deploy an official Sui/Move package with:
        - `created_by` — the address who created the attestation
        - `data` — the extra fields stored in the specific “attestation type”
    - Created attestation will be transferred to the attested package or module
-   - Revoking attestations will be possible by the same sender as original `created_by`, unless the attestation type is explicitly created as irrevocable
+   - Attestation creation function will return `RevokeCap` object, which can be used to revoke original attestation
 - A per-sender list of trusted attestation types. It will allow known entities to recommend specific types reviewed and approved by the community.
 - A per-sender list of trusted attesters. It will allow users to publicly “follow” or “unfollow” specific attesters, while keeping a list of them independent from the app they are using: an explorer, a wallet or a package manager.
 

--- a/sips/sip-trust_signals.md
+++ b/sips/sip-trust_signals.md
@@ -1,7 +1,7 @@
 |   SIP-Number |  |
 |         ---: | :--- |
 |        Title | Attestation registry |
-|  Description | Open standard for attesters to share signals about packages or modules |
+|  Description | Open standard for attesters to share signals about packages |
 |       Author | Sidestream Labs https://labs.sidestream.tech |
 |       Editor |  |
 |         Type | Informational |
@@ -12,51 +12,60 @@
 
 ## Abstract
 
-Open standard for attesters to share signals about packages or modules.
+Open standard for attesters to share signals about packages.
 
 ## Motivation
 
-Currently, there is no straightforward way for the users to ensure safety of a particular package they plan to interact with. This document proposes to create a central registry that will allow:
-    1. Security professionals to provide various attestations for packages or modules
-    2. Regular Sui users to easily discover relevant attestations for a specific package
+Currently, there is no straightforward way for the users to ensure the safety of a particular package they plan to interact with. This document proposes to create a central registry that will allow:
+1. Security professionals to provide various attestations for packages.
+2. Regular Sui users can easily discover relevant attestations for a specific package.
+3. Package owners to highlight certain attestations related to their package.
 
 ## Specification
 
-We propose to develop and deploy an official Sui/Move package with:
-- A permissionless "attestation type" registry. It will allow anyone to create new discoverable attestation types
-    - Once created, the attestation will be frozen
-    - Each attestation type will have required base qualities
-        - `id` — UID of the attestation type
-        - `type_name` — `std::type_name::get<T>()` of the `attestation.data` type
-            - Enforced to be unique to prevent two attestation types with the same `type_name`
-    - Each attestation type can introduce a custom arbitrary logic implemented in an external module that defines `<T>` type (for example, the whitelisting logic of who can issue attestations can be implemented this way)
-    - The sender would be required to create Display type for their attestation type
-    - Created Display type will be immutable to prevent misleading updates or renames
-- A permissionless attestation registry. It will allow anyone to create new attestations using any existing attestation types
-   - Once created, the attestation can not be transferred or deleted
-   - Each attestation will have obligatory set of fields
-       - `id` — UID of the attestation
-       - `receiver` – the address which is being attested
-       - `created_by` — the address who created the attestation
-       - `data` — the extra fields stored in the specific “attestation type”
-   - Created attestation will be transferred to the attested package or module
-   - Attestation creation function will return `RevokeCap` object, which can be used to revoke original attestation
+We propose to develop an official `attestation` package that will act as a central registry for the security-related signals about packages. More specifically, it will define:
+
+- A permissionless `attestation::attest` method for creating attestations of `Attestation<T>` type
+    - Each attestation will have a standard set of fields:
+        - `id` — UID of the attestation
+        - `receiver` — the package address that is being attested
+        - `created_by` — the address of the user who created the attestation
+        - `pinned_by` — the optional address of the user who pinned the attestation
+        - `revoked_by` — the optional address of the user who revoked the attestation
+        - `revoke_cap_id` — the ID of the `RevokeCap` (capability to revoke this attestation)
+        - `data` — the extra fields of type `T`, defined by the specific "attestation type" package
+    - Once created, the attestation is stored inside package `Registry` and is never deleted
+    - The user-created attestation is expected to receive `RevokeCap` which can later be used to revoke the attestation (marking it no longer valid) using the `attestation::revoke` method. Note: the package that implements the `T` type can decide to freeze `RevokeCap` (making an attestation type that can not be revoked) or define other arbitrary revocation logic.
+
+- A permissionless `attestation::register_type` method for registering new `AttestationType`s. It will allow anyone to register a package which defines arbitrary `T` type (for example, an `Audit` type which contains fields like `auditUrl` and `auditHash`) and relevant methods to interact with the `attestation` package
+    - Creation of a new `AttestationType` will require:
+        - `Publisher` object of the package that defined the `T` type.
+        - Arrays of matching `fields` and `values` used to create a `Display` object for the new `Attestation<T>` type.
+    - Once created, the `Publisher` as well as the newly created `Display` objects will be frozen and can no longer be used to update the package or the `Display` object.
+    - Each attestation type package can introduce custom arbitrary logic, for example, restrict users who can issue attestations or define custom revocation logic.
+    - The package shall expose at least a standard `attest` function.
+
+- Permissioned `attestation::pin` and `attestation::unpin` methods for highlighting specific attestations, accessible only by the `Publisher`s of the previously attested package.
+    - Example usage scenario:
+        1. A newly deployed package gets audited, and the auditors issue `Audit` attestation to that package (i.e., specifying the package address as a `receiver` of their attestation).
+        2. The `Publisher` of the newly audited package decides to highlight the attestation, calling the `attestation::pin` method.
+        3. Block explorers and other frontends that have `attestation` integration could choose to display pinned attestations above all others.
+        4. Once pinned, attestation gets revoked by the `RevokeCap` owners or unpinned by the receiver `Publisher` it is no longer highlighted.
 
 ## Rationale
 
-The main target of this proposed standard is the end user interacting with packages and modules on Sui blockchain. Therefore, explorers and wallets should be able to index created attestations and provide contextual information to the users.
+The main target of this proposed standard is the end user interacting with packages and modules on the Sui blockchain. Therefore, explorers and wallets should be able to index created attestations and provide contextual information to the users.
 
-We wish to enable the Sui community to define exact attestation types suitable for their needs, therefore the proposal makes attestations and attestation types fully permissionless and extensible. Although we would also plan to define first attestation types and provide intended example usage for common use-cases like security audits.
+We wish to enable the Sui community to define exact attestation types suitable for their needs; therefore, the proposal makes attestations and attestation types fully permissionless and extensible. Although we also plan to define first attestation types and provide intended example usage for common use cases like security audits, those are intentionally not part of this SIP.
 
 ## Backwards Compatibility
 
-There are no issues with backwards compatibility, as this proposal focuses on establishing a new standard.
+There are no issues with backward compatibility, as this proposal focuses on establishing a new standard.
 
 ## Reference Implementation
 
-Is developed by Sidestream Labs in [sidestream-tech/sui-attestation-registry](https://github.com/sidestream-tech/sui-attestation-registry).
-
+Reference implementation is developed by Sidestream Labs in [sidestream-tech/sui-attestation-registry](https://github.com/sidestream-tech/sui-attestation-registry) together with example attestation type packages.
 
 ## Security Considerations
 
-As the ownership of the Attestation objects will be used as a way to define “attested” address, transferability of the Attestation objects should be restricted and stay restricted. Likely the package upgradability will need to be sacrificed to avoid possibility of its misuse.
+The future upgrade of this package might change some of the principles described here.


### PR DESCRIPTION
This PR creates a SIP draft, that intends to specify open standard for attesters to share signals about packages or modules, as per the original RFP "Record trust signals for packages onchain". 