### PR TITLE
SIP: PTB Type Argument Interpolation

### DIFF
--- a/sips/sip-ptb_type_interpolation.md
+++ b/sips/sip-ptb_type_interpolation.md
@@ -1,0 +1,256 @@
+|   SIP-Number | |
+|         ---: | :--- |
+|        Title | PTB Type Argument Interpolation |
+|  Description | Enables type arguments in PTB commands to reference Results from prior commands, allowing publish-and-use in a single transaction. |
+|       Author | Greshamscode, @92GC |
+|       Editor | <Leave this blank; it will be assigned by a SIP Editor> |
+|         Type | Standard |
+|     Category | Framework |
+|      Created | 2025-06-25 |
+| Comments-URI | |
+|       Status | |
+|     Requires | |
+
+## Abstract
+
+This proposal extends Programmable Transaction Blocks (PTBs) to allow type arguments in `MoveCall` commands to reference `Result` values from prior commands in the same transaction. Currently, type arguments must be fully-resolved string literals at PTB construction time. This limitation prevents "publish-and-use" workflows where a module is deployed and immediately used in the same transaction.
+
+## Motivation
+
+### The Problem: Two-Transaction Minimum for New Coin Types
+
+Sui's type system requires all generic type parameters to be known at compile time. When building a PTB, type arguments must be string literals like `"0xabc123::my_module::MyType"`.
+
+This creates a fundamental limitation: **you cannot use a type from a package you just published in the same PTB**.
+
+```typescript
+const ptb = new Transaction();
+
+// Step 1: Publish a new coin module
+const [upgradeCap] = ptb.publish({
+  modules: compiledModules,
+  dependencies: [...]
+});
+// upgradeCap contains the new package ID, but it's a Result - a runtime value
+
+// Step 2: Try to use the new coin type - FAILS
+ptb.moveCall({
+  target: `${existingPkg}::escrow::register_coin`,
+  typeArguments: [`${???}::my_coin::MY_COIN`], // Can't interpolate Result!
+  arguments: [...],
+});
+```
+
+The `publish` command returns the package ID as a `Result`, but type arguments only accept string literals. There is no way to construct a type string that references the just-published package.
+
+### Real-World Impact
+
+This limitation forces protocols to choose between:
+
+1. **Two-transaction workflows**: Publish in one transaction, use in another (poor UX, race conditions)
+2. **Pre-deployed type pools**: Maintain registries of pre-created types that can be acquired on-demand (complex infrastructure, coordination overhead)
+3. **Factory patterns with limited flexibility**: Use existing types instead of creating new ones (limits expressiveness)
+
+None of these are ideal. The core issue is that "publish and use atomically" is impossible.
+
+### Who Benefits
+
+- **Token launchpads**: Single-click token creation with immediate liquidity pool setup
+- **Prediction markets**: Unique coin types per outcome, created and used atomically
+- **Gaming/NFT protocols**: Mint new item types and immediately use them in-game
+- **DeFi protocols**: Deploy new pool types and seed initial liquidity in one transaction
+- **Any protocol needing dynamic types**: Currently forced into multi-transaction flows or complex workarounds
+
+## Specification
+
+### New PTB Command Variant
+
+Extend the `MoveCall` command to accept a new type argument format:
+
+```typescript
+interface TypeArgumentFromResult {
+  kind: "Result";
+  result: TransactionResult;  // Reference to a prior Publish command
+  module: string;             // Module name within the published package
+  type: string;               // Type name within the module
+  typeParams?: TypeArgument[]; // Optional nested type parameters
+}
+
+type TypeArgument = string | TypeArgumentFromResult;
+```
+
+### SDK Usage
+
+```typescript
+const ptb = new Transaction();
+
+// Publish returns package info including the package ID
+const publishResult = ptb.publish({
+  modules: compiledModules,
+  dependencies: [...]
+});
+
+// Use the new type immediately
+ptb.moveCall({
+  target: `${existingPkg}::escrow::register_coin`,
+  typeArguments: [
+    ptb.typeFromResult(publishResult, "my_coin", "MY_COIN")
+  ],
+  arguments: [registry, treasuryCap, ...],
+});
+```
+
+### Transaction Execution Semantics
+
+1. **Ordering**: Type argument resolution happens **after** prior commands complete but **before** the Move VM executes the current command
+2. **Validation**: The runtime verifies that:
+   - The referenced `Result` is from a `Publish` command
+   - The `Publish` command succeeded
+   - The specified module and type exist in the published package
+3. **Type String Construction**: The runtime constructs the full type string: `{package_id}::{module}::{type}`
+4. **Failure Handling**: If resolution fails (module doesn't exist, type doesn't exist), the transaction aborts
+
+### BCS Encoding
+
+For transaction serialization, add a new variant to the type argument enum:
+
+```rust
+enum TypeArgument {
+    // Existing: fully resolved type string
+    Pure(String),
+    // New: reference to a Result
+    FromResult {
+        result_index: u16,
+        module_name: String,
+        type_name: String,
+        type_params: Vec<TypeArgument>,
+    },
+}
+```
+
+## Rationale
+
+### Why This Approach?
+
+**Option 1: Runtime Type Creation (Rejected)**
+Adding dynamic type creation (`coin::create_dynamic()`) would fundamentally change Move's static type system. Move's security guarantees depend on types being known at compile time. This is too invasive.
+
+**Option 2: Deferred Type Resolution / Closures (Rejected)**
+Adding closures or callbacks to Move would require language-level changes: new syntax, compiler modifications, VM changes, gas metering for closures. This is a much larger undertaking.
+
+**Option 3: PTB Type Interpolation (This Proposal)**
+This is the most surgical approach:
+- No Move language changes
+- No Move bytecode verifier changes
+- Move contracts remain unchanged
+- Only the PTB execution layer needs modification
+- Sui already does Result-based resolution for object arguments
+
+### Implementation Complexity
+
+The Sui runtime already:
+- Tracks `Result` values from prior PTB commands
+- Resolves object references at execution time
+- Knows the package ID from successful `Publish` commands
+
+Extending this to type arguments is a natural evolution of existing infrastructure.
+
+### No Breaking Changes
+
+Existing PTBs continue to work exactly as before. The new `FromResult` type argument variant is additive.
+
+## Backwards Compatibility
+
+This proposal is purely additive:
+- Existing transactions with string-literal type arguments work unchanged
+- Existing SDK code works unchanged
+- Only new code using `typeFromResult` would use the new capability
+
+SDKs would need updates to support the new syntax, but older SDKs would continue to function for existing use cases.
+
+## Test Cases
+
+### Basic Publish-and-Use
+
+```typescript
+const ptb = new Transaction();
+const pub = ptb.publish({ modules: coinModule, dependencies: [] });
+
+ptb.moveCall({
+  target: "0x2::coin::mint",
+  typeArguments: [ptb.typeFromResult(pub, "my_coin", "MY_COIN")],
+  arguments: [treasuryCap, amount],
+});
+```
+
+Expected: Single transaction publishes coin module and mints initial supply.
+
+### Nested Type Parameters
+
+```typescript
+ptb.moveCall({
+  target: `${pkg}::pool::create`,
+  typeArguments: [
+    ptb.typeFromResult(pub, "token_a", "TOKEN_A"),
+    ptb.typeFromResult(pub, "token_b", "TOKEN_B"),
+    `${lpPkg}::lp::LP`
+  ],
+  arguments: [...],
+});
+```
+
+Expected: Type arguments can mix Result-based and literal types.
+
+### Invalid Module Reference
+
+```typescript
+ptb.moveCall({
+  typeArguments: [ptb.typeFromResult(pub, "nonexistent", "TYPE")],
+  ...
+});
+```
+
+Expected: Transaction aborts with clear error: "Module 'nonexistent' not found in package {id}".
+
+## Reference Implementation
+
+A reference implementation would modify:
+
+1. **Transaction format**: Add `FromResult` variant to type argument enum
+2. **PTB executor**: Resolve `FromResult` type arguments before Move execution
+3. **SDK**: Add `typeFromResult` helper method
+
+The core change is in the PTB executor's command processing loop:
+
+```rust
+fn resolve_type_arguments(
+    type_args: Vec<TypeArgument>,
+    results: &[CommandResult],
+) -> Result<Vec<String>, Error> {
+    type_args.into_iter().map(|arg| match arg {
+        TypeArgument::Pure(s) => Ok(s),
+        TypeArgument::FromResult { result_index, module_name, type_name, type_params } => {
+            let publish_result = &results[result_index as usize];
+            let package_id = publish_result.as_publish()?.package_id;
+            let resolved_params = resolve_type_arguments(type_params, results)?;
+            Ok(format_type_string(package_id, module_name, type_name, resolved_params))
+        }
+    }).collect()
+}
+```
+
+## Security Considerations
+
+1. **No New Capabilities**: This does not grant any new ability to create types at runtime. Types must still be defined in published modules. This only changes *when* the type string is resolved.
+
+2. **Ordering Guarantees**: The `Publish` command must complete successfully before any command can reference its types. The PTB executor already enforces command ordering.
+
+3. **Validation**: Type existence is validated at resolution time. Invalid module/type references abort the transaction cleanly.
+
+4. **No Type Spoofing**: The package ID comes directly from the `Publish` result - callers cannot inject arbitrary addresses.
+
+5. **Gas Metering**: Type resolution is a string operation with minimal overhead. No new gas considerations beyond existing string operations.
+
+## Copyright
+
+Greshamscode 2025

--- a/sips/sip-ptb_type_interpolation.md
+++ b/sips/sip-ptb_type_interpolation.md
@@ -13,112 +13,41 @@
 
 ## Abstract
 
-This proposal extends Programmable Transaction Blocks (PTBs) to allow type arguments in `MoveCall` commands to reference `Result` values from prior commands in the same transaction. Currently, type arguments must be fully-resolved string literals at PTB construction time. This limitation prevents "publish-and-use" workflows where a module is deployed and immediately used in the same transaction.
+Extend PTBs to allow type arguments to reference `Result` values from prior commands. Currently type arguments must be string literals, preventing "publish-and-use" in a single transaction.
 
 ## Motivation
 
-### The Problem: Two-Transaction Minimum for New Coin Types
-
-Sui's type system requires all generic type parameters to be known at compile time. When building a PTB, type arguments must be string literals like `"0xabc123::my_module::MyType"`.
-
-This creates a fundamental limitation: **you cannot use a type from a package you just published in the same PTB**.
+You cannot use a type from a package you just published in the same PTB:
 
 ```typescript
 const ptb = new Transaction();
+const [upgradeCap] = ptb.publish({ modules, dependencies });
 
-// Step 1: Publish a new coin module
-const [upgradeCap] = ptb.publish({
-  modules: compiledModules,
-  dependencies: [...]
-});
-// upgradeCap contains the new package ID, but it's a Result - a runtime value
-
-// Step 2: Try to use the new coin type - FAILS
+// FAILS - type arguments only accept string literals
 ptb.moveCall({
-  target: `${existingPkg}::escrow::register_coin`,
+  target: `${pkg}::escrow::register_coin`,
   typeArguments: [`${???}::my_coin::MY_COIN`], // Can't interpolate Result!
-  arguments: [...],
 });
 ```
 
-The `publish` command returns the package ID as a `Result`, but type arguments only accept string literals. There is no way to construct a type string that references the just-published package.
-
-### Real-World Impact
-
-This limitation forces protocols to choose between:
-
-1. **Two-transaction workflows**: Publish in one transaction, use in another (poor UX, race conditions)
-2. **Pre-deployed type pools**: Maintain registries of pre-created types that can be acquired on-demand (complex infrastructure, coordination overhead)
-3. **Factory patterns with limited flexibility**: Use existing types instead of creating new ones (limits expressiveness)
-
-None of these are ideal. The core issue is that "publish and use atomically" is impossible.
-
-### Who Benefits
-
-- **Token launchpads**: Single-click token creation with immediate liquidity pool setup
-- **Prediction markets**: Unique coin types per outcome, created and used atomically
-- **Gaming/NFT protocols**: Mint new item types and immediately use them in-game
-- **DeFi protocols**: Deploy new pool types and seed initial liquidity in one transaction
-- **Any protocol needing dynamic types**: Currently forced into multi-transaction flows or complex workarounds
+This forces two-transaction workflows for token launches, prediction markets, and any protocol creating types dynamically.
 
 ## Specification
 
-### New PTB Command Variant
-
-Extend the `MoveCall` command to accept a new type argument format:
+Add a new type argument variant that references a `Publish` result:
 
 ```typescript
-interface TypeArgumentFromResult {
-  kind: "Result";
-  result: TransactionResult;  // Reference to a prior Publish command
-  module: string;             // Module name within the published package
-  type: string;               // Type name within the module
-  typeParams?: TypeArgument[]; // Optional nested type parameters
-}
-
-type TypeArgument = string | TypeArgumentFromResult;
-```
-
-### SDK Usage
-
-```typescript
-const ptb = new Transaction();
-
-// Publish returns package info including the package ID
-const publishResult = ptb.publish({
-  modules: compiledModules,
-  dependencies: [...]
-});
-
-// Use the new type immediately
+// SDK usage
+const pub = ptb.publish({ modules, dependencies });
 ptb.moveCall({
-  target: `${existingPkg}::escrow::register_coin`,
-  typeArguments: [
-    ptb.typeFromResult(publishResult, "my_coin", "MY_COIN")
-  ],
-  arguments: [registry, treasuryCap, ...],
+  typeArguments: [ptb.typeFromResult(pub, "my_coin", "MY_COIN")],
 });
 ```
-
-### Transaction Execution Semantics
-
-1. **Ordering**: Type argument resolution happens **after** prior commands complete but **before** the Move VM executes the current command
-2. **Validation**: The runtime verifies that:
-   - The referenced `Result` is from a `Publish` command
-   - The `Publish` command succeeded
-   - The specified module and type exist in the published package
-3. **Type String Construction**: The runtime constructs the full type string: `{package_id}::{module}::{type}`
-4. **Failure Handling**: If resolution fails (module doesn't exist, type doesn't exist), the transaction aborts
-
-### BCS Encoding
-
-For transaction serialization, add a new variant to the type argument enum:
 
 ```rust
+// BCS encoding
 enum TypeArgument {
-    // Existing: fully resolved type string
     Pure(String),
-    // New: reference to a Result
     FromResult {
         result_index: u16,
         module_name: String,
@@ -128,128 +57,33 @@ enum TypeArgument {
 }
 ```
 
+The runtime resolves `FromResult` after the `Publish` completes, constructing `{package_id}::{module}::{type}`.
+
 ## Rationale
 
-### Why This Approach?
+This is surgical—no Move language or bytecode verifier changes. The PTB executor already resolves `Result` references for objects; extending this to type arguments is natural.
 
-**Option 1: Runtime Type Creation (Rejected)**
-Adding dynamic type creation (`coin::create_dynamic()`) would fundamentally change Move's static type system. Move's security guarantees depend on types being known at compile time. This is too invasive.
-
-**Option 2: Deferred Type Resolution / Closures (Rejected)**
-Adding closures or callbacks to Move would require language-level changes: new syntax, compiler modifications, VM changes, gas metering for closures. This is a much larger undertaking.
-
-**Option 3: PTB Type Interpolation (This Proposal)**
-This is the most surgical approach:
-- No Move language changes
-- No Move bytecode verifier changes
-- Move contracts remain unchanged
-- Only the PTB execution layer needs modification
-- Sui already does Result-based resolution for object arguments
-
-### Implementation Complexity
-
-The Sui runtime already:
-- Tracks `Result` values from prior PTB commands
-- Resolves object references at execution time
-- Knows the package ID from successful `Publish` commands
-
-Extending this to type arguments is a natural evolution of existing infrastructure.
-
-### No Breaking Changes
-
-Existing PTBs continue to work exactly as before. The new `FromResult` type argument variant is additive.
+Alternatives rejected:
+- **Runtime type creation**: Too invasive to Move's static type system
+- **Closures/deferred execution**: Requires language-level changes
 
 ## Backwards Compatibility
 
-This proposal is purely additive:
-- Existing transactions with string-literal type arguments work unchanged
-- Existing SDK code works unchanged
-- Only new code using `typeFromResult` would use the new capability
-
-SDKs would need updates to support the new syntax, but older SDKs would continue to function for existing use cases.
+Purely additive. Existing PTBs work unchanged.
 
 ## Test Cases
 
-### Basic Publish-and-Use
-
-```typescript
-const ptb = new Transaction();
-const pub = ptb.publish({ modules: coinModule, dependencies: [] });
-
-ptb.moveCall({
-  target: "0x2::coin::mint",
-  typeArguments: [ptb.typeFromResult(pub, "my_coin", "MY_COIN")],
-  arguments: [treasuryCap, amount],
-});
-```
-
-Expected: Single transaction publishes coin module and mints initial supply.
-
-### Nested Type Parameters
-
-```typescript
-ptb.moveCall({
-  target: `${pkg}::pool::create`,
-  typeArguments: [
-    ptb.typeFromResult(pub, "token_a", "TOKEN_A"),
-    ptb.typeFromResult(pub, "token_b", "TOKEN_B"),
-    `${lpPkg}::lp::LP`
-  ],
-  arguments: [...],
-});
-```
-
-Expected: Type arguments can mix Result-based and literal types.
-
-### Invalid Module Reference
-
-```typescript
-ptb.moveCall({
-  typeArguments: [ptb.typeFromResult(pub, "nonexistent", "TYPE")],
-  ...
-});
-```
-
-Expected: Transaction aborts with clear error: "Module 'nonexistent' not found in package {id}".
+To be developed.
 
 ## Reference Implementation
 
-A reference implementation would modify:
-
-1. **Transaction format**: Add `FromResult` variant to type argument enum
-2. **PTB executor**: Resolve `FromResult` type arguments before Move execution
-3. **SDK**: Add `typeFromResult` helper method
-
-The core change is in the PTB executor's command processing loop:
-
-```rust
-fn resolve_type_arguments(
-    type_args: Vec<TypeArgument>,
-    results: &[CommandResult],
-) -> Result<Vec<String>, Error> {
-    type_args.into_iter().map(|arg| match arg {
-        TypeArgument::Pure(s) => Ok(s),
-        TypeArgument::FromResult { result_index, module_name, type_name, type_params } => {
-            let publish_result = &results[result_index as usize];
-            let package_id = publish_result.as_publish()?.package_id;
-            let resolved_params = resolve_type_arguments(type_params, results)?;
-            Ok(format_type_string(package_id, module_name, type_name, resolved_params))
-        }
-    }).collect()
-}
-```
+To be developed.
 
 ## Security Considerations
 
-1. **No New Capabilities**: This does not grant any new ability to create types at runtime. Types must still be defined in published modules. This only changes *when* the type string is resolved.
-
-2. **Ordering Guarantees**: The `Publish` command must complete successfully before any command can reference its types. The PTB executor already enforces command ordering.
-
-3. **Validation**: Type existence is validated at resolution time. Invalid module/type references abort the transaction cleanly.
-
-4. **No Type Spoofing**: The package ID comes directly from the `Publish` result - callers cannot inject arbitrary addresses.
-
-5. **Gas Metering**: Type resolution is a string operation with minimal overhead. No new gas considerations beyond existing string operations.
+- **No new capabilities**: Types must still be defined in published modules
+- **Ordering enforced**: `Publish` must succeed before types can be referenced
+- **Validation**: Invalid module/type references abort cleanly
 
 ## Copyright
 

--- a/sips/sip-ptb_type_interpolation.md
+++ b/sips/sip-ptb_type_interpolation.md
@@ -1,7 +1,7 @@
 |   SIP-Number | |
 |         ---: | :--- |
-|        Title | PTB Type Argument Interpolation |
-|  Description | Enables type arguments in PTB commands to reference Results from prior commands, allowing publish-and-use in a single transaction. |
+|        Title | PTB Publish-Result Interpolation |
+|  Description | Enables later PTB commands to reference types and call targets from an earlier Publish command. |
 |       Author | Greshamscode, @92GC |
 |       Editor | <Leave this blank; it will be assigned by a SIP Editor> |
 |         Type | Standard |
@@ -13,67 +13,147 @@
 
 ## Abstract
 
-PTB type args only accept string literals. If you publish a package, you don't know the package ID until the tx lands — so you can't use your new types as generics in the same transaction. This adds a `FromResult` variant to the type argument encoding and `typeFromResult()` to the SDK. No Move or VM changes — the executor already resolves Result references for objects, this extends that to type args.
+This proposal allows a PTB command to derive both a Move type argument and a Move-call target from an earlier `Publish` command. It enables a single transaction to publish a package, call its initialization functions, and use its newly defined types with existing protocols.
+
+The referenced functions and types must exist in the successfully published package. Move continues to execute ordinary concrete types from verified bytecode.
 
 ## Motivation
 
-You cannot use a type from a package you just published in the same PTB:
+The package ID created by `Publish` is not known while a PTB is being constructed. Consequently, later commands cannot:
+
+1. call a function in the newly published package; or
+2. use a type from that package as a generic argument to an existing package.
 
 ```typescript
 const ptb = new Transaction();
-const [upgradeCap] = ptb.publish({ modules, dependencies });
+const publication = ptb.publish({ modules, dependencies });
 
-// FAILS - type arguments only accept string literals
+// Fails: the newly published package ID is unknown.
+const [treasuryCap] = ptb.moveCall({
+  target: `${???}::my_coin::create_currency`,
+  arguments: [coinRegistry],
+});
+
+// Fails: the newly published type cannot be encoded yet.
 ptb.moveCall({
-  target: `${pkg}::escrow::register_coin`,
-  typeArguments: [`${???}::my_coin::MY_COIN`], // Can't interpolate Result!
+  target: `${pasPackage}::policy::new_for_currency`,
+  typeArguments: [`${???}::my_coin::MY_COIN`],
+  arguments: [namespace, treasuryCap, false],
 });
 ```
 
-This forces two-transaction workflows for token launches, prediction markets, and any protocol creating types dynamically.
+This forces multi-transaction workflows for token launches, permissioned assets, prediction markets, and protocols that generate proposal-specific types.
+
+## PAS and Conditional Assets
+
+PAS creates a policy for an existing currency type and requires its treasury capability:
+
+```move
+policy::new_for_currency<C>(
+    namespace,
+    treasury_cap: &mut TreasuryCap<C>,
+    clawback_allowed,
+)
+```
+
+A just-in-time conditional asset workflow therefore needs to:
+
+1. publish the module defining `C`;
+2. call that module to create and return `TreasuryCap<C>`;
+3. pass `C` and the capability to PAS;
+4. register the asset with a market or governance protocol; and
+5. create the associated proposal.
+
+Type interpolation solves step 3, while target interpolation makes step 2 callable.
 
 ## Specification
 
-Add a new type argument variant that references a `Publish` result:
+The SDK exposes publish-derived references equivalent to:
 
 ```typescript
-// SDK usage
-const pub = ptb.publish({ modules, dependencies });
-ptb.moveCall({
-  typeArguments: [ptb.typeFromResult(pub, "my_coin", "MY_COIN")],
+const publication = ptb.publish({ modules, dependencies });
+
+const coinType = ptb.typeFromResult(
+  publication,
+  "my_coin",
+  "MY_COIN",
+);
+
+const [treasuryCap] = ptb.moveCall({
+  target: ptb.targetFromResult(
+    publication,
+    "my_coin",
+    "create_currency",
+  ),
+  arguments: [coinRegistry],
+});
+
+const [policy, policyCap] = ptb.moveCall({
+  target: `${pasPackage}::policy::new_for_currency`,
+  typeArguments: [coinType],
+  arguments: [namespace, treasuryCap, false],
 });
 ```
 
-```rust
-// BCS encoding
-enum TypeArgument {
-    Pure(String),
-    FromResult {
-        result_index: u16,
-        module_name: String,
-        type_name: String,
-        type_params: Vec<TypeArgument>,
-    },
-}
-```
+At the protocol level, a Move call's package reference supports either a static package ID or a reference to an earlier `Publish` command. Type arguments similarly support normal static type tags or a struct type whose package is derived from an earlier `Publish` command.
 
-The runtime resolves `FromResult` after the `Publish` completes, constructing `{package_id}::{module}::{type}`.
+Publish-derived struct types may contain nested static or publish-derived type arguments, subject to the existing transaction-size and type-depth limits.
+
+## Resolution
+
+Before executing a publish-derived Move call, the execution adapter:
+
+1. verifies that the reference identifies an earlier `Publish` command;
+2. obtains the package ID created by that command;
+3. resolves the requested module, function, and types;
+4. validates visibility, type abilities, and the function signature; and
+5. executes the call with normal concrete Move types.
+
+An invalid command reference, module, function, type, or type parameter aborts the transaction.
 
 ## Rationale
 
-This is surgical—no Move language or bytecode verifier changes. The PTB executor already resolves `Result` references for objects; extending this to type arguments is natural.
+This is transaction-level late binding of a package ID, not runtime type creation. The signed transaction commits to the package bytecode, dependencies, module names, function names, and type names. The only value derived during execution is the package ID created by the referenced `Publish` command.
 
-Alternatives rejected:
-- **Runtime type creation**: Too invasive to Move's static type system
-- **Closures/deferred execution**: Requires language-level changes
+Supporting both type arguments and call targets completes the publish-initialize-register workflow. Type-only interpolation is sufficient when the new type is immediately consumed by an existing package, but not when initialization must call a factory function in the newly published package.
+
+## Non-Goals
+
+This proposal does not:
+
+- create types without publishing verified Move bytecode;
+- expose types as Move values;
+- add runtime generics or existential types;
+- derive package references from arbitrary address-valued command results; or
+- expose arbitrary objects created and transferred by module initializers.
+
+Packages requiring same-PTB composition should expose public functions that return capabilities such as `TreasuryCap<C>` as command results.
+
+## Implementation Impact
+
+This proposal requires additive changes to:
+
+- the PTB transaction model and BCS encoding;
+- TypeScript and Rust transaction builders;
+- transaction validation;
+- package and type resolution during execution; and
+- protocol-version gating, gas accounting, and tests.
+
+No Move source-language or Move bytecode-format changes are required.
 
 ## Backwards Compatibility
 
-Purely additive. Existing PTBs work unchanged.
+Purely additive. Existing PTBs and static Move-call targets continue to work unchanged.
 
 ## Test Cases
 
-To be developed.
+- Publish a package and use one of its types in a call to an existing package.
+- Publish a package and call one of its public functions later in the same PTB.
+- Return a capability from the new package and pass it to an existing generic function.
+- Resolve nested generic types containing a publish-derived type.
+- Reject forward references and references to non-`Publish` commands.
+- Reject missing modules, functions, types, and invalid type parameters.
+- Preserve normal visibility and ability checking.
 
 ## Reference Implementation
 
@@ -81,9 +161,11 @@ To be developed.
 
 ## Security Considerations
 
-- **No new capabilities**: Types must still be defined in published modules
-- **Ordering enforced**: `Publish` must succeed before types can be referenced
-- **Validation**: Invalid module/type references abort cleanly
+- References may only point backward to an earlier successful `Publish` command.
+- The executor derives the package ID; callers cannot substitute an arbitrary runtime address.
+- Normal package linking, visibility, type-ability, and function-signature checks remain enforced.
+- Resolution depth and size must remain bounded and metered.
+- The transaction signature commits to every symbolic reference and to the published package contents.
 
 ## Copyright
 

--- a/sips/sip-ptb_type_interpolation.md
+++ b/sips/sip-ptb_type_interpolation.md
@@ -13,7 +13,7 @@
 
 ## Abstract
 
-Extend PTBs to allow type arguments to reference `Result` values from prior commands. Currently type arguments must be string literals, preventing "publish-and-use" in a single transaction.
+PTB type args only accept string literals. If you publish a package, you don't know the package ID until the tx lands — so you can't use your new types as generics in the same transaction. This adds a `FromResult` variant to the type argument encoding and `typeFromResult()` to the SDK. No Move or VM changes — the executor already resolves Result references for objects, this extends that to type args.
 
 ## Motivation
 


### PR DESCRIPTION
# Summary

  Extend PTBs so later commands can reference both:

  1. types defined by an earlier `Publish` command; and
  2. functions inside the newly published package.

  Currently package IDs must be known when the PTB is constructed. This prevents atomic workflows that publish a package,
  initialize its assets, and register those assets with existing protocols such as PAS or Govex.

  ## The Problem

  ```typescript
  const ptb = new Transaction();
  const publication = ptb.publish({ modules, dependencies });

  // FAILS: cannot call a function in the newly published package.
  const [treasuryCap] = ptb.moveCall({
    target: `${???}::my_coin::create_currency`,
    arguments: [coinRegistry],
  });

  // FAILS: cannot use the newly published type with an existing package.
  ptb.moveCall({
    target: `${pasPackage}::policy::new_for_currency`,
    typeArguments: [`${???}::my_coin::MY_COIN`],
    arguments: [namespace, treasuryCap, false],
  });
  ```

  This is particularly relevant to PAS.

  PAS creates a policy for an existing currency type:

  ```move
  policy::new_for_currency<C>(
      namespace,
      treasury_cap: &mut TreasuryCap<C>,
      clawback_allowed,
  )
  ```

  A JIT workflow therefore needs to:

  1. publish the module defining `C`;
  2. call that module to create and return `TreasuryCap<C>`;
  3. pass `C` and its `TreasuryCap<C>` to PAS;
  4. register the asset with Govex and create the proposal.

  Type-argument interpolation solves step 3, but calling the newly published currency factory also requires target-package
  interpolation.

  ## The Solution

  ```typescript
  const publication = ptb.publish({ modules, dependencies });

  const coinType = ptb.typeFromResult(
    publication,
    "my_coin",
    "MY_COIN",
  );

  const [treasuryCap] = ptb.moveCall({
    target: ptb.targetFromResult(
      publication,
      "my_coin",
      "create_currency",
    ),
    arguments: [coinRegistry],
  });

  const [policy, policyCap] = ptb.moveCall({
    target: `${pasPackage}::policy::new_for_currency`,
    typeArguments: [coinType],
    arguments: [namespace, treasuryCap, false],
  });

  ptb.moveCall({
    target: `${govexPackage}::proposal::register_conditional_asset`,
    typeArguments: [coinType],
    arguments: [proposal, treasuryCap, policy],
  });
  ```

  This enables a single PTB to:

  - create its currency and `TreasuryCap`;
  - create its PAS policy;
  - register it with Govex; and
  - create the proposal.