### PR TITLE
SIP: PTB Structural Digest

### DIFF
--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -1,0 +1,257 @@
+|   SIP-Number | |
+|         ---: | :--- |
+|        Title | PTB Command Context & Scoped Execution |
+|  Description | Expose PTB command history to Move and enable isolated execution scopes within transactions |
+|       Author | Greshamscode, @92GC |
+|       Editor | |
+|         Type | Standard |
+|     Category | Framework |
+|      Created | 2025-02-04 |
+| Comments-URI | |
+|       Status | |
+
+## Abstract
+
+Three related enhancements to PTBs:
+1. **Command Context** - Expose previous command info (package, module, function) to Move
+2. **Scoped Execution** - Isolate groups of commands that share internal context but not external
+3. **Scope Witness** - Cryptographic proof that commands belong to same scope
+
+## Motivation
+
+Move functions are blind to their PTB context:
+- Cannot verify which package/function called them
+- Cannot see PTB command history
+- No way to create isolated "sub-transactions" within atomic PTB
+
+**Use cases:**
+- Verifiable dynamic dispatch without application-level hot potatoes
+- Publish-and-use with type interpolation (see SIP: PTB Type Argument Interpolation)
+- Isolated token launches where inner commands can't leak to outer PTB
+- Cross-protocol trust verification
+- **Preventing AMM censorship of arbitrage** (see below)
+
+### AMM Censorship Problem
+
+Without scopes, AMMs could inspect PTB context and refuse to execute if they detect arbitrage:
+
+```move
+// Malicious AMM could do this:
+public fun swap(ctx: &TxContext, ...) {
+    let prev = ptb_context::previous_command(ctx);
+    let next = ptb_context::command_at(ctx, ptb_context::current_index(ctx) + 1);
+
+    // Refuse if sandwich detected
+    if (is_competing_amm(prev) || is_competing_amm(next)) {
+        abort ENoArbitrageAllowed
+    };
+}
+```
+
+**Consequences:**
+- **Liquidity fragmentation** - AMMs can't be freely composed, fragmenting global liquidity
+- **Validator MEV** - Validators see full PTB before execution, can front-run/censor arbitrage
+- **Rent extraction** - AMMs become gatekeepers, extracting value from traders
+
+**Scopes solve this:**
+```typescript
+// User wraps each AMM call in isolated scope
+ptb.scope({ inheritContext: false }, (s) => s.moveCall({ target: "amm_a::swap" }));
+ptb.scope({ inheritContext: false }, (s) => s.moveCall({ target: "amm_b::swap" }));
+// Neither AMM can see the other exists in this PTB
+```
+
+This preserves:
+- Atomic execution (both swaps succeed or both fail)
+- Composability (any AMM can be combined)
+- MEV resistance (pattern not visible to contracts)
+
+## Specification
+
+### Part 1: Command Context
+
+```move
+module sui::ptb_context {
+    /// Command types in PTB - defined as enum for type safety
+    public enum CommandType has copy, drop {
+        MoveCall,
+        TransferObjects,
+        SplitCoins,
+        MergeCoins,
+        Publish,
+        MakeMoveVec,
+        Upgrade,
+        Scope,
+    }
+
+    public struct CommandInfo has copy, drop {
+        index: u16,
+        command_type: CommandType,
+        package_id: address,    // MoveCall/Upgrade only
+        module_name: String,    // MoveCall only
+        function_name: String,  // MoveCall only
+    }
+
+    /// Current command's index in PTB (or scope)
+    public native fun current_index(ctx: &TxContext): u16;
+
+    /// Total commands in current scope
+    public native fun total_commands(ctx: &TxContext): u16;
+
+    /// Get command info at index (must be < current_index)
+    public native fun command_at(ctx: &TxContext, index: u16): Option<CommandInfo>;
+
+    /// Convenience: previous command
+    public fun previous_command(ctx: &TxContext): Option<CommandInfo> {
+        let idx = current_index(ctx);
+        if (idx == 0) option::none()
+        else command_at(ctx, idx - 1)
+    }
+
+    /// Scope nesting depth (1 = top-level PTB or explicit scope, increments for nested)
+    /// NOTE: Top-level PTB is indistinguishable from explicit scope - both return 1
+    /// This prevents contracts from detecting whether caller used Scope command
+    public native fun scope_depth(ctx: &TxContext): u8;
+}
+```
+
+### Part 2: Scoped Execution
+
+New `Command` variant:
+
+```rust
+enum Command {
+    // ... existing ...
+    Scope {
+        commands: Vec<Command>,
+        inherit_context: bool,  // Can inner see outer command history?
+    },
+}
+```
+
+**Semantics:**
+- Commands inside scope share internal context
+- `current_index()` resets to 0 inside scope
+- `command_at()` only returns scope-internal commands (unless `inherit_context`)
+- Results can flow out via normal `Result(scope_idx)` references
+- Scopes can nest (scope_depth increments)
+
+**SDK:**
+```typescript
+ptb.scope({ inheritContext: false }, (scope) => {
+    const pub = scope.publish({ modules, deps });
+    scope.moveCall({ target: `...`, typeArguments: [scope.typeFromResult(pub, "mod", "Type")] });
+});
+```
+
+### Part 3: Scope Witness
+
+```move
+module sui::ptb_context {
+    /// Witness proving commands are in same scope
+    public struct ScopeWitness has drop {
+        scope_id: u256,
+        creator_index: u16,
+        scope_depth: u8,
+    }
+
+    /// Create witness (marks current command as scope anchor)
+    public native fun create_scope_witness(ctx: &mut TxContext): ScopeWitness;
+
+    /// Verify caller is in same scope as witness creator
+    public native fun in_same_scope(ctx: &TxContext, witness: &ScopeWitness): bool;
+
+    /// Get scope_id of current scope (unique per scope instance)
+    public native fun current_scope_id(ctx: &TxContext): u256;
+}
+```
+
+## Rationale
+
+**Why expose command history?**
+- Enables trustless verification of caller identity
+- No opt-in required (unlike hot potato patterns)
+- Read-only - cannot enforce ordering, just verify
+
+**Why scopes?**
+- Publish-and-use requires isolation (new types shouldn't leak)
+- Composability with boundaries (protocol A calls protocol B without exposing internals)
+- **Prevent AMM/protocol censorship** - contracts can't refuse execution based on surrounding PTB context
+- **Preserve global liquidity** - AMMs remain freely composable for arbitrage
+- **MEV resistance** - arbitrage patterns hidden from contracts (validators still see, but can't selectively abort)
+- Gas accounting per scope (future: parallel execution hints)
+
+**Why not expose parameters?**
+- Too expensive (arbitrary BCS data)
+- Type safety issues (how to represent in Move?)
+- Security risk (parameter inspection enables new attack vectors)
+
+**Why not expose `is_scoped()`?**
+- Would allow contracts to detect if caller used Scope command
+- Defeats isolation purpose - AMMs could refuse non-scoped calls
+- Instead, `scope_depth()` returns 1 for both top-level PTB and explicit scope
+
+**Alternatives rejected:**
+- Full call stack introspection - too invasive, breaks function isolation assumptions
+- Mutable context - allows state smuggling between commands
+
+## Backwards Compatibility
+
+Purely additive:
+- New native functions in `sui::ptb_context`
+- New `Scope` command variant
+- Existing PTBs work unchanged
+- `ptb_context` functions return sensible defaults for non-scoped execution
+
+## Security Considerations
+
+**Command Context:**
+- Read-only - cannot modify history
+- Only past commands visible (not future)
+- Package ID is immutable (Original ID, not upgraded address)
+
+**Scopes:**
+- Inner scope cannot access outer scope's Results unless explicitly passed
+- `inherit_context: false` provides strict isolation
+- Scope witness cannot be forged (VM-generated scope_id)
+
+**Attack vectors to consider:**
+- Scope escape via object references (mitigated: objects still owned normally)
+- Context spoofing (mitigated: native functions, not user-controllable)
+- Gas exhaustion via deep nesting (mitigated: max scope depth limit)
+
+**Design tension: Exposure vs Hiding**
+
+Part 1 (Command Context) and Part 2 (Scopes) create intentional tension:
+- Context exposure enables verifiable dispatch (good for security)
+- Scopes enable context hiding (good for composability/MEV resistance)
+
+Resolution: **User controls the boundary**
+- Protocols that WANT caller verification use Part 1 (governance, vaults)
+- Protocols that SHOULD NOT discriminate are called within scopes (AMMs, orderbooks)
+- User decides isolation level per-call via `inheritContext` flag
+
+## Test Cases
+
+To be developed:
+- Command history accuracy across command types
+- Scope isolation verification
+- Nested scope behavior
+- Scope witness validity checks
+- inherit_context: true vs false behavior
+
+## Reference Implementation
+
+To be developed.
+
+## Open Questions
+
+1. **Max scope depth?** Suggest 64 (sufficient for most use cases, limits complexity)
+2. **Scope gas limits?** Should scopes have independent gas budgets?
+3. **Result visibility?** Can outer PTB reference inner scope Results by index?
+4. **Error semantics?** Does inner scope failure abort entire PTB? (suggest yes - atomic)
+5. **Type interpolation interaction?** Should `typeFromResult` work across scope boundaries?
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -8,10 +8,9 @@ Add one native function on `sui::tx_context`:
 public fun current_command_range_hash(ctx: &TxContext, additional_commands: u64): vector<u8>
 ```
 
-This returns a versioned hash of the current PTB command and the next
-`additional_commands` commands.
+This returns a versioned hash of a given sequential range of the current PTB commands.
 
-The point is simple: let a contract lock in the part of a PTB it cares about,
+This let's a contract lock in the part of a PTB it cares about,
 while leaving the rest of the PTB open for wallets, solvers, sponsors, or other
 composition.
 

--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -1,7 +1,7 @@
 |   SIP-Number | |
 |         ---: | :--- |
-|        Title | PTB Command Context & Scoped Execution |
-|  Description | Expose PTB command metadata and argument provenance to Move; add scoped execution for isolation |
+|        Title | PTB Dynamic Dispatch via Command Context & Scoped Execution |
+|  Description | Enable dynamic dispatch in PTBs by exposing command metadata and argument origins to Move; add scoped execution for isolation |
 |       Author | Greshamscode, @92GC |
 |       Editor | |
 |         Type | Standard |
@@ -12,17 +12,19 @@
 
 ## Abstract
 
-Four additions to PTBs:
-1. **Command Context** — Any command in a scope can read metadata (package, module, function) of every other command in that scope.
-2. **Argument Provenance** — Track which command produced each argument, enabling origin verification.
-3. **Scoped Execution** — Partition PTB commands into isolated groups that share internal context but hide it from the outside.
-4. **Scope Witness** — Proof that two commands executed in the same scope.
+This SIP enables dynamic dispatch in PTBs. Today, composing protocols requires pre-built hot potato wrappers for every integration — new protocol means new wrapper code. We propose letting contracts inspect which commands are in their PTB scope and where argument values came from, so they can verify callers and value origins at runtime. No wrappers needed.
+
+Concretely, four additions:
+1. Expose command metadata (package, module, function) to all commands within a scope
+2. Track which command produced each argument passed to a function
+3. A new `Scope` command that partitions PTB commands into isolated groups
+4. A witness proving two commands share a scope
 
 ## Motivation
 
-Composing Move protocols today requires hot potato wrappers for every integration. A DAO executing "vault spend → DEX swap → vault deposit" needs a custom wrapper action for each DEX. New DEX = new wrapper code.
+A DAO wants to execute "vault spend → DEX swap → vault deposit." Today this requires a wrapper action per DEX that type-checks the coin flow at compile time. Adding a new DEX means writing and deploying new wrapper code.
 
-With command context + argument provenance, the deposit function can verify at runtime that the coin it received came from an approved package — no wrapper needed:
+With this proposal, the deposit function verifies at runtime that the coin came from an approved package:
 
 ```move
 public fun deposit_from_approved<CoinType>(ctx: &TxContext, coin: Coin<CoinType>) {
@@ -33,11 +35,15 @@ public fun deposit_from_approved<CoinType>(ctx: &TxContext, coin: Coin<CoinType>
 }
 ```
 
-Scopes solve the flipside: without them, a protocol could inspect context and refuse execution when it sees a competitor in the same PTB. Scopes partition commands so each group only sees its own context, preventing censorship while keeping the transaction atomic.
+Adding a new DEX becomes an allowlist update, not new code.
+
+Scopes solve the flipside: without isolation, a protocol could inspect context and refuse execution when it sees a competitor. Scopes partition commands so each group only sees its own context, preventing censorship while keeping the transaction atomic.
 
 ## Specification
 
 ### 1. Command Context
+
+A new `sui::ptb_context` module exposes metadata about commands in the current scope.
 
 ```move
 module sui::ptb_context {
@@ -78,6 +84,8 @@ module sui::ptb_context {
 All commands within a scope can see all other commands in that scope. Visibility does not cross scope boundaries unless `inherit_context` is set.
 
 ### 2. Argument Provenance
+
+Extends `sui::ptb_context` with argument origin tracking.
 
 ```move
 module sui::ptb_context {
@@ -149,9 +157,9 @@ module sui::ptb_context {
 
 ## Rationale
 
-**Full scope visibility (not past-only):** Restricting to past commands would still allow ordering games. Full visibility within a scope is simpler and lets contracts verify the complete execution context they're part of. Scopes are the isolation boundary, not command ordering.
+**Full scope visibility (not past-only):** Restricting to past commands would still allow ordering games. Full visibility within a scope is simpler and lets contracts verify the complete execution context. Scopes are the isolation boundary, not command ordering.
 
-**Scopes, not `is_scoped()`:** Exposing whether a call is scoped would let protocols refuse non-scoped calls, defeating the purpose. `scope_depth()` returns 1 for both top-level and explicit scopes — indistinguishable.
+**Scopes, not `is_scoped()`:** Exposing whether a call is scoped lets protocols refuse non-scoped calls, defeating the purpose. `scope_depth()` returns 1 for both top-level and explicit scopes — indistinguishable.
 
 **No parameter exposure:** Too expensive (arbitrary BCS), type-unsafe, and argument provenance covers the important cases.
 

--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -1,201 +1,267 @@
-|   SIP-Number | |
-|         ---: | :--- |
-|        Title | PTB Dynamic Dispatch via Command Context & Scoped Execution |
-|  Description | Enable dynamic dispatch in PTBs by exposing command metadata and argument origins to Move; add scoped execution for isolation |
-|       Author | Greshamscode, @92GC |
-|       Editor | |
-|         Type | Standard |
-|     Category | Framework |
-|      Created | 2025-02-04 |
-| Comments-URI | |
-|       Status | |
+# SIP-70: Current Command Range Hash
 
-## Abstract
+## Summary
 
-This SIP enables dynamic dispatch in PTBs. Today, composing protocols requires pre-built hot potato wrappers for every integration — new protocol means new wrapper code. We propose letting contracts inspect which commands are in their PTB scope and where argument values came from, so they can verify callers and value origins at runtime. No wrappers needed.
+Add one native function on `sui::tx_context`:
 
-Concretely, four additions:
-1. Expose command metadata (package, module, function) to all commands within a scope
-2. Track which command produced each argument passed to a function
-3. A new `Scope` command that partitions PTB commands into isolated groups
-4. A witness proving two commands share a scope
+```move
+public fun current_command_range_hash(ctx: &TxContext, additional_commands: u64): vector<u8>
+```
+
+This returns a versioned hash of the current PTB command and the next
+`additional_commands` commands.
+
+The point is simple: let a contract lock in the part of a PTB it cares about,
+while leaving the rest of the PTB open for wallets, solvers, sponsors, or other
+composition.
+
+This is more useful than a whole-PTB hash for smart accounts and governance,
+because the authorized intent can be fixed without forcing the whole transaction
+to be fixed.
 
 ## Motivation
 
-A DAO wants to execute "vault spend → DEX swap → vault deposit." Today this requires a wrapper action per DEX that type-checks the coin flow at compile time. Adding a new DEX means writing and deploying new wrapper code.
+Apps currently need execution wrappers for every new function they want to call.
+This is messy UX and prevents JIT execution.
 
-With this proposal, the deposit function verifies at runtime that the coin came from an approved package:
+This lets smart accounts, DAOs, and account-abstraction systems act as wallets
+and interact seamlessly without hard-coded pre-deployed wrappers.
 
-```move
-public fun deposit_from_approved<CoinType>(ctx: &TxContext, coin: Coin<CoinType>) {
-    let source = ptb_context::argument_source(ctx, 0);
-    assert!(source.is_some(), ENotFromPTBResult);
-    let cmd = ptb_context::command_at(ctx, source.borrow().command_index());
-    assert!(is_approved(cmd.package_id), EUnauthorizedSource);
-}
-```
+`current_command_range_hash(ctx, additional_commands)` keeps the primitive at
+the PTB layer:
 
-Adding a new DEX becomes an allowlist update, not new code.
+- fixed intent commands can be committed to
+- solver/wallet commands before or after the range can stay open
+- Move receives only an opaque hash
+- no PTB introspection is exposed
 
-Scopes solve the flipside: without isolation, a protocol could inspect context and refuse execution when it sees a competitor. Scopes partition commands so each group only sees its own context, preventing censorship while keeping the transaction atomic.
+This is idiomatic because it makes fixed intents and open solver execution
+composable without leaking PTB abstractions into Move.
 
 ## Specification
 
-### 1. Command Context
-
-A new `sui::ptb_context` module exposes metadata about commands in the current scope.
+### Move API
 
 ```move
-module sui::ptb_context {
-    public enum CommandType has copy, drop {
-        MoveCall,
-        TransferObjects,
-        SplitCoins,
-        MergeCoins,
-        Publish,
-        MakeMoveVec,
-        Upgrade,
-        Scope,
-    }
-
-    public struct CommandInfo has copy, drop {
-        index: u16,
-        command_type: CommandType,
-        package_id: address,    // MoveCall/Upgrade only, @0x0 otherwise
-        module_name: String,    // MoveCall only
-        function_name: String,  // MoveCall only
-    }
-
-    /// Current command's index in its scope
-    public native fun current_index(ctx: &TxContext): u16;
-
-    /// Total commands in current scope
-    public native fun total_commands(ctx: &TxContext): u16;
-
-    /// Get info for any command in the current scope
-    public native fun command_at(ctx: &TxContext, index: u16): Option<CommandInfo>;
-
-    /// Scope nesting depth. Top-level PTB and explicit scope both return 1
-    /// (indistinguishable by design — prevents contracts from detecting scope usage)
-    public native fun scope_depth(ctx: &TxContext): u8;
+module sui::tx_context {
+    /// Returns a hash of the current command and the next `additional_commands`
+    /// commands.
+    /// Output: [version_byte | blake2b256_hash] (33 bytes).
+    public fun current_command_range_hash(
+        _self: &TxContext,
+        additional_commands: u64,
+    ): vector<u8>;
 }
 ```
 
-All commands within a scope can see all other commands in that scope. Visibility does not cross scope boundaries unless `inherit_context` is set.
+The current command is the PTB command that is currently executing this native.
+For example, if command 4 calls a smart account function that calls
+`current_command_range_hash(ctx, 2)`, the hash covers commands 4, 5, and 6.
 
-### 2. Argument Provenance
+The current command is included in the hash.
 
-Extends `sui::ptb_context` with argument origin tracking.
+`additional_commands = 0` hashes the current command only.
+
+Because the current command is included, the expected hash should come from
+authenticated object state, such as an approved account or DAO intent. It should
+not be passed as a pure argument to the command being hashed.
+
+### Output Format
+
+```text
+[version_byte | blake2b256_hash]
+```
+
+- version `0x01` = current command range hash scheme
+- total output: 33 bytes
+
+If fewer than `additional_commands` commands remain after the current command,
+the function returns a domain-separated unavailable hash, not an abort. The
+unavailable hash must not collide with any valid command range hash. Callers
+should treat it as a normal hash comparison failure.
+
+This lets contracts safely write:
 
 ```move
-module sui::ptb_context {
-    public enum ArgumentSource has copy, drop {
-        Input { input_index: u16 },
-        Result { command_index: u16, result_index: u16 },
-        NestedResult { command_index: u16, result_index: u16 },
-    }
-
-    /// Source of the argument at the given index (excluding implicit &TxContext)
-    public native fun argument_source(ctx: &TxContext, arg_index: u8): Option<ArgumentSource>;
-
-    /// Check if argument came from a specific command
-    public fun argument_is_from_command(ctx: &TxContext, arg_index: u8, command_index: u16): bool {
-        let source = argument_source(ctx, arg_index);
-        if (source.is_none()) return false;
-        match (*source.borrow()) {
-            ArgumentSource::Result { command_index: idx, .. } => idx == command_index,
-            ArgumentSource::NestedResult { command_index: idx, .. } => idx == command_index,
-            _ => false,
-        }
-    }
-}
+let actual = tx_context::current_command_range_hash(ctx, additional_commands);
+assert!(
+    actual == expected_hash,
+    EHashMismatch,
+);
 ```
 
-### 3. Scoped Execution
+without also needing to introspect PTB length.
 
-New PTB command variant:
+### What Is Hashed
 
-```rust
-enum Command {
-    // ... existing variants ...
-    Scope {
-        commands: Vec<Command>,
-        inherit_context: bool,
-    },
-}
+The hash commits to the selected contiguous command range only.
+
+For every command in the range, the encoder commits to:
+
+- command kind
+- package, module, function, and type arguments for Move calls
+- command-specific data for non-Move-call commands
+- argument count and argument structure
+- result flow between commands inside the range
+- imported values from outside the range, as imports
+
+All strings, byte blobs, and lists are length-framed. That means the hash input
+includes each field's length before the field bytes, so two different command
+encodings cannot collide by concatenating to the same byte string.
+
+### What Is Not Hashed
+
+The hash does not commit to:
+
+- sender/caller address
+- sponsor address
+- signatures
+- transaction digest
+- gas budget
+- gas price
+- gas coin object ID
+- gas coin version
+- object versions
+- commands before the selected range
+- commands after the selected range
+- absolute command position
+
+The VM may use the current command index internally to compute the range, but
+the API exposes only the hash. It does not expose position, depth, frame kind, or
+whether the caller is inside any higher-level application abstraction.
+
+### Argument Normalization
+
+Each PTB argument is normalized before hashing:
+
+| Argument Type | What Gets Hashed | Rationale |
+| --- | --- | --- |
+| `GasCoin` | marker only | gas coin identity is sender-dependent and should not be part of intent |
+| `Pure(bytes)` | exact bytes | fixed parameter value |
+| `SharedObject` | ObjectID + mutability mode | mutability changes lock/call semantics, so it is hashed; object versions are not stable |
+| `ImmOrOwnedObject` | ObjectID | version can drift between authorization and execution |
+| `Receiving` | ObjectID | version can drift |
+| result inside range | relative command/result index | commits to flow inside the locked range |
+| result before range | import slot | allows solver/wallet setup before the locked range |
+
+Direct PTB inputs are fixed. If a command in the range uses a direct object or
+pure input, that value is part of the hash.
+
+If a command in the range uses a value produced by a command before the range,
+that value is encoded as an import. The hash commits that an imported value is
+used, and where it is used, but not to the full command sequence that produced
+it.
+
+Import slots are assigned by first use inside the range. Reusing the same
+external value reuses the same import slot. Different external values get
+different import slots.
+
+This is the key composability property: a solver can do any number of setup
+commands first, then route values into the fixed range, without changing the
+range hash.
+
+### Hash Construction
+
+Conceptually:
+
+```text
+range_hash = 0x01 || Blake2b256(
+    "SUI_CURRENT_COMMAND_RANGE_HASH"
+    || additional_commands
+    || for each selected command in order:
+        Blake2b256(
+            command_kind
+            || length_framed(command_specific_data)
+            || normalized_arguments
+        )
+)
 ```
 
-- `current_index()` resets to 0 inside a scope
-- `command_at()` returns only scope-internal commands (unless `inherit_context: true`)
-- Argument provenance indices are scope-relative
-- Results flow out via normal `Result(scope_idx)` references
-- Scopes nest; `scope_depth` increments accordingly
+The concrete encoder should be semantic and versioned, not raw BCS of the PTB
+Rust type. Future PTB shape changes can then be handled by the encoder instead
+of changing the Move API.
 
-SDK usage:
-```typescript
-ptb.scope({ inheritContext: false }, (scope) => {
-    const pub = scope.publish({ modules, deps });
-    scope.moveCall({ target: `...`, typeArguments: [scope.typeFromResult(pub, "mod", "Type")] });
-});
+### Example
+
+The wallet or solver can build:
+
+```text
+0. solver setup command
+1. solver setup command
+2. smart_account::execute_intent(account, intent_id, 2, ctx)
+3. fixed intent command
+4. fixed intent command
+5. solver settlement command
 ```
 
-### 4. Scope Witness
+Inside command 2, the smart account checks:
 
 ```move
-module sui::ptb_context {
-    public struct ScopeWitness has drop {
-        scope_id: u256,
-        creator_index: u16,
-        scope_depth: u8,
-    }
-
-    public native fun create_scope_witness(ctx: &mut TxContext): ScopeWitness;
-    public native fun in_same_scope(ctx: &TxContext, witness: &ScopeWitness): bool;
-    public native fun current_scope_id(ctx: &TxContext): u256;
-}
+let expected_hash = smart_account::approved_hash(account, intent_id);
+let actual = tx_context::current_command_range_hash(ctx, 2);
+assert!(actual == expected_hash, EHashMismatch);
 ```
 
-## Rationale
+The hash covers commands 2, 3, and 4.
 
-**Full scope visibility (not past-only):** Restricting to past commands would still allow ordering games. Full visibility within a scope is simpler and lets contracts verify the complete execution context. Scopes are the isolation boundary, not command ordering.
+Commands 0, 1, and 5 are not hashed. The solver can change them without
+changing the authorized intent, as long as the locked range still receives the
+right imported values and has the same command structure.
 
-**Scopes, not `is_scoped()`:** Exposing whether a call is scoped lets protocols refuse non-scoped calls, defeating the purpose. `scope_depth()` returns 1 for both top-level and explicit scopes — indistinguishable.
+The expected hash is loaded from the smart account's approved intent state. It
+is not a caller-supplied pure argument, so the hash does not require a fixed
+point.
 
-**No parameter exposure:** Too expensive (arbitrary BCS), type-unsafe, and argument provenance covers the important cases.
+## Why Not Full PTB Hash
 
-**Exposure vs hiding is intentional:** Context lets governance protocols verify callers. Scopes let DeFi protocols stay composable. The user picks the boundary per call.
+A full PTB hash is too rigid for the main use case.
 
-## Backwards Compatibility
+Smart accounts and governance usually want to authorize the important part of a
+transaction, not the exact gas setup, solver route, sponsorship details, or
+settlement tail.
 
-Purely additive. Existing PTBs work unchanged. `ptb_context` functions return sensible defaults pre-feature. `argument_source` returns `None` for pre-feature commands.
+A range hash lets the authorized part stay fixed while solver, wallet, and
+sponsorship logic stays flexible.
+
+## Implementation Notes
+
+This can be implemented with the same broad machinery as a structural digest,
+but scoped to the current command range:
+
+1. Store or expose the current `ProgrammableTransaction` to `TxContext` during
+   execution.
+2. Track the currently executing command index internally in the PTB executor.
+3. When the native is called, hash the inclusive range
+   `[current_index, current_index + additional_commands]`.
+4. Encode in-range result references relatively.
+5. Encode references to earlier results as imports.
+6. Return the unavailable hash if the requested range runs past the end.
+7. Charge base gas plus a per-byte/per-command cost for the hashed range.
+
+The current command index is execution metadata. It is not returned to Move and
+is not part of the public API.
 
 ## Security Considerations
 
-- Read-only — commands can inspect context but not modify it
-- All commands in a scope see each other; scopes are the privacy boundary
-- Package IDs are Original IDs (immutable, not upgraded addresses)
-- Provenance is VM-tracked and unforgeable
-- Scope witnesses are VM-generated — cannot be spoofed
-- Max scope depth limit prevents gas exhaustion via deep nesting
-- Contracts should validate values, not just their provenance
+- VM-computed and read-only
+- order-sensitive within the selected range
+- flow-sensitive within the selected range
+- no sender/caller address or gas coin identity in the hash
+- no PTB introspection
+- no way to ask for absolute PTB position
+- commands outside the range remain intentionally open
 
-## Open Questions
+Contracts should compare the returned hash against an expected hash that was
+computed off-chain using the same versioned encoder.
 
-1. Max scope depth? (suggest 64)
-2. Should scopes have independent gas budgets?
-3. Can outer PTB reference inner scope Results by index?
-4. Does inner scope failure abort the entire PTB? (suggest yes)
-5. Should `typeFromResult` work across scope boundaries?
-6. Should `&TxContext` count as arg 0 or be excluded from indexing?
+## Backwards Compatibility
 
-## Test Cases
+Purely additive. This adds one new native function behind a protocol version.
 
-To be developed.
+The version byte lets future hash schemes coexist with existing stored hashes.
 
-## Reference Implementation
+## Future Work
 
-To be developed.
-
-## Copyright
-
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+- SDK support for off-chain range hash computation
+- test vectors for common smart-account and solver patterns
+- optional helper APIs in wallets for building PTBs around a locked range

--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -1,7 +1,7 @@
 |   SIP-Number | |
 |         ---: | :--- |
 |        Title | PTB Command Context & Scoped Execution |
-|  Description | Expose PTB command history to Move and enable isolated execution scopes within transactions |
+|  Description | Expose PTB command history and argument provenance to Move, enabling dynamic dispatch and isolated scopes |
 |       Author | Greshamscode, @92GC |
 |       Editor | |
 |         Type | Standard |
@@ -12,59 +12,83 @@
 
 ## Abstract
 
-Three related enhancements to PTBs:
+Four related enhancements to PTBs:
 1. **Command Context** - Expose previous command info (package, module, function) to Move
-2. **Scoped Execution** - Isolate groups of commands that share internal context but not external
-3. **Scope Witness** - Cryptographic proof that commands belong to same scope
+2. **Argument Provenance** - Track which command produced each argument passed to a function
+3. **Scoped Execution** - Isolate groups of commands that share internal context but not external
+4. **Scope Witness** - Cryptographic proof that commands belong to same scope
 
 ## Motivation
 
-Move functions are blind to their PTB context:
-- Cannot verify which package/function called them
-- Cannot see PTB command history
-- No way to create isolated "sub-transactions" within atomic PTB
+### The Hot Potato Problem
 
-**Use cases:**
-- Verifiable dynamic dispatch without application-level hot potatoes
-- Publish-and-use with type interpolation (see SIP: PTB Type Argument Interpolation)
-- Isolated token launches where inner commands can't leak to outer PTB
-- Cross-protocol trust verification
-- **Preventing AMM censorship of arbitrage** (see below)
+Today, composing Move protocols requires **application-level hot potatoes** - wrapper actions that must be pre-built for every external protocol integration.
 
-### AMM Censorship Problem
+Example: A DAO wants to execute "spend USDC → swap on Cetus → deposit result":
 
-Without scopes, AMMs could inspect PTB context and refuse to execute if they detect arbitrage:
+```
+Current approach:
+  Intent stages: [VaultSpend → CetusSwapWrapper → VaultDeposit]
+                              ↑
+                    Must pre-build this action
+                    Type-checks coin flow at compile time
+                    New protocol = new wrapper
+```
+
+This creates:
+- **Action explosion** - Every protocol integration needs custom wrapper code
+- **Upgrade burden** - Protocol upgrades require action updates
+- **Reduced composability** - Can't use protocols without pre-built wrappers
+
+### Dynamic Dispatch: The Solution
+
+With PTB Command Context + Argument Provenance, DAOs can verify constraints at runtime:
+
+```
+New approach:
+  Intent stages: [VaultSpend → <any approved protocol> → VaultDeposit]
+                              ↑
+                    No wrapper needed!
+                    Runtime verification via ptb_context
+```
+
+The deposit action verifies:
+1. "The coin I'm receiving came from command N" (argument provenance)
+2. "Command N was a call to an approved package" (command context)
 
 ```move
-// Malicious AMM could do this:
-public fun swap(ctx: &TxContext, ...) {
-    let prev = ptb_context::previous_command(ctx);
-    let next = ptb_context::command_at(ctx, ptb_context::current_index(ctx) + 1);
+public fun deposit_from_approved_source<CoinType>(
+    ctx: &TxContext,
+    coin: Coin<CoinType>,
+) {
+    // Verify coin came from a PTB Result (not raw Input)
+    let source_idx = ptb_context::argument_source(ctx, 1); // arg 1 = coin
+    assert!(source_idx.is_some(), ENotFromPTBResult);
 
-    // Refuse if sandwich detected
-    if (is_competing_amm(prev) || is_competing_amm(next)) {
-        abort ENoArbitrageAllowed
-    };
+    // Verify source command was approved protocol
+    let source_cmd = ptb_context::command_at(ctx, *source_idx.borrow());
+    assert!(is_approved_defi_protocol(source_cmd.package_id), EUnauthorizedSource);
+
+    // Proceed with deposit...
 }
 ```
 
-**Consequences:**
-- **Liquidity fragmentation** - AMMs can't be freely composed, fragmenting global liquidity
-- **Validator MEV** - Validators see full PTB before execution, can front-run/censor arbitrage
-- **Rent extraction** - AMMs become gatekeepers, extracting value from traders
+**Result**: No more wrapper actions. Integrate any protocol by adding it to an approved list.
 
-**Scopes solve this:**
-```typescript
-// User wraps each AMM call in isolated scope
-ptb.scope({ inheritContext: false }, (s) => s.moveCall({ target: "amm_a::swap" }));
-ptb.scope({ inheritContext: false }, (s) => s.moveCall({ target: "amm_b::swap" }));
-// Neither AMM can see the other exists in this PTB
+### Secondary Benefits
+
+**Scoped Execution** prevents protocol censorship:
+
+Without scopes, protocols could inspect PTB context and refuse to execute:
+```move
+// Malicious AMM could refuse arbitrage:
+if (is_competing_amm(previous_command(ctx))) abort ENoArbitrageAllowed;
 ```
 
-This preserves:
-- Atomic execution (both swaps succeed or both fail)
-- Composability (any AMM can be combined)
-- MEV resistance (pattern not visible to contracts)
+Scopes hide context between isolated groups of commands, preserving:
+- Atomic execution (all-or-nothing)
+- Free composability (any protocol combination)
+- MEV resistance (patterns hidden from contracts)
 
 ## Specification
 
@@ -87,9 +111,9 @@ module sui::ptb_context {
     public struct CommandInfo has copy, drop {
         index: u16,
         command_type: CommandType,
-        package_id: address,    // MoveCall/Upgrade only
-        module_name: String,    // MoveCall only
-        function_name: String,  // MoveCall only
+        package_id: address,    // MoveCall/Upgrade only, @0x0 for others
+        module_name: String,    // MoveCall only, empty for others
+        function_name: String,  // MoveCall only, empty for others
     }
 
     /// Current command's index in PTB (or scope)
@@ -98,7 +122,7 @@ module sui::ptb_context {
     /// Total commands in current scope
     public native fun total_commands(ctx: &TxContext): u16;
 
-    /// Get command info at index (must be < current_index)
+    /// Get command info at index (must be < current_index, past only)
     public native fun command_at(ctx: &TxContext, index: u16): Option<CommandInfo>;
 
     /// Convenience: previous command
@@ -115,7 +139,52 @@ module sui::ptb_context {
 }
 ```
 
-### Part 2: Scoped Execution
+### Part 2: Argument Provenance
+
+```move
+module sui::ptb_context {
+    /// Argument source types
+    public enum ArgumentSource has copy, drop {
+        /// Value came from transaction Input (provided by sender)
+        Input { input_index: u16 },
+        /// Value came from a previous command's Result
+        Result { command_index: u16, result_index: u16 },
+        /// Value came from nested Result (e.g., Result(5, 0) for first return of command 5)
+        NestedResult { command_index: u16, result_index: u16 },
+    }
+
+    /// Get the source of argument at given index for current command
+    /// arg_index 0 = first argument (excluding &TxContext which is implicit)
+    /// Returns None if argument tracking unavailable
+    public native fun argument_source(ctx: &TxContext, arg_index: u8): Option<ArgumentSource>;
+
+    /// Convenience: check if argument came from a specific command's result
+    public fun argument_is_from_command(ctx: &TxContext, arg_index: u8, command_index: u16): bool {
+        let source = argument_source(ctx, arg_index);
+        if (source.is_none()) return false;
+
+        match (*source.borrow()) {
+            ArgumentSource::Result { command_index: idx, .. } => idx == command_index,
+            ArgumentSource::NestedResult { command_index: idx, .. } => idx == command_index,
+            _ => false,
+        }
+    }
+
+    /// Convenience: get command index that produced this argument (if Result-based)
+    public fun argument_command_index(ctx: &TxContext, arg_index: u8): Option<u16> {
+        let source = argument_source(ctx, arg_index);
+        if (source.is_none()) return option::none();
+
+        match (*source.borrow()) {
+            ArgumentSource::Result { command_index, .. } => option::some(command_index),
+            ArgumentSource::NestedResult { command_index, .. } => option::some(command_index),
+            _ => option::none(),
+        }
+    }
+}
+```
+
+### Part 3: Scoped Execution
 
 New `Command` variant:
 
@@ -133,6 +202,7 @@ enum Command {
 - Commands inside scope share internal context
 - `current_index()` resets to 0 inside scope
 - `command_at()` only returns scope-internal commands (unless `inherit_context`)
+- `argument_source()` returns indices relative to current scope
 - Results can flow out via normal `Result(scope_idx)` references
 - Scopes can nest (scope_depth increments)
 
@@ -144,7 +214,7 @@ ptb.scope({ inheritContext: false }, (scope) => {
 });
 ```
 
-### Part 3: Scope Witness
+### Part 4: Scope Witness
 
 ```move
 module sui::ptb_context {
@@ -173,6 +243,11 @@ module sui::ptb_context {
 - No opt-in required (unlike hot potato patterns)
 - Read-only - cannot enforce ordering, just verify
 
+**Why argument provenance?**
+- Completes the verification story: know WHAT called you AND WHERE values came from
+- Enables "accept coin only if it came from approved protocol" pattern
+- Type safety preserved by Move's type system; provenance adds origin verification
+
 **Why scopes?**
 - Publish-and-use requires isolation (new types shouldn't leak)
 - Composability with boundaries (protocol A calls protocol B without exposing internals)
@@ -181,14 +256,20 @@ module sui::ptb_context {
 - **MEV resistance** - arbitrage patterns hidden from contracts (validators still see, but can't selectively abort)
 - Gas accounting per scope (future: parallel execution hints)
 
+**Why not expose future commands?**
+- Would allow contracts to enforce specific PTB structure
+- Breaks composability (can't add cleanup commands after)
+- Creates ordering games between protocols
+
 **Why not expose parameters?**
 - Too expensive (arbitrary BCS data)
 - Type safety issues (how to represent in Move?)
 - Security risk (parameter inspection enables new attack vectors)
+- Argument provenance provides sufficient information for most use cases
 
 **Why not expose `is_scoped()`?**
 - Would allow contracts to detect if caller used Scope command
-- Defeats isolation purpose - AMMs could refuse non-scoped calls
+- Defeats isolation purpose - protocols could refuse non-scoped calls
 - Instead, `scope_depth()` returns 1 for both top-level PTB and explicit scope
 
 **Alternatives rejected:**
@@ -202,6 +283,7 @@ Purely additive:
 - New `Scope` command variant
 - Existing PTBs work unchanged
 - `ptb_context` functions return sensible defaults for non-scoped execution
+- `argument_source` returns `None` for commands executed before this feature
 
 ## Security Considerations
 
@@ -210,24 +292,32 @@ Purely additive:
 - Only past commands visible (not future)
 - Package ID is immutable (Original ID, not upgraded address)
 
+**Argument Provenance:**
+- Read-only tracking of PTB execution flow
+- Cannot forge provenance (VM-tracked)
+- Useful for allowlist-based verification, not for preventing all attacks
+- Contracts should still validate values themselves, not just their source
+
 **Scopes:**
 - Inner scope cannot access outer scope's Results unless explicitly passed
 - `inherit_context: false` provides strict isolation
 - Scope witness cannot be forged (VM-generated scope_id)
+- Argument provenance indices are scope-relative (cannot reference out-of-scope commands)
 
 **Attack vectors to consider:**
 - Scope escape via object references (mitigated: objects still owned normally)
 - Context spoofing (mitigated: native functions, not user-controllable)
 - Gas exhaustion via deep nesting (mitigated: max scope depth limit)
+- Provenance-based allowlist bypass (mitigated: contracts should validate values, not just source)
 
 **Design tension: Exposure vs Hiding**
 
-Part 1 (Command Context) and Part 2 (Scopes) create intentional tension:
-- Context exposure enables verifiable dispatch (good for security)
+Parts 1-2 (Context + Provenance) and Part 3 (Scopes) create intentional tension:
+- Context exposure enables verifiable dispatch (good for governance, security)
 - Scopes enable context hiding (good for composability/MEV resistance)
 
 Resolution: **User controls the boundary**
-- Protocols that WANT caller verification use Part 1 (governance, vaults)
+- Protocols that WANT caller verification use Parts 1-2 (governance, vaults, DAOs)
 - Protocols that SHOULD NOT discriminate are called within scopes (AMMs, orderbooks)
 - User decides isolation level per-call via `inheritContext` flag
 
@@ -235,10 +325,12 @@ Resolution: **User controls the boundary**
 
 To be developed:
 - Command history accuracy across command types
+- Argument provenance tracking for all argument sources (Input, Result, NestedResult)
 - Scope isolation verification
 - Nested scope behavior
 - Scope witness validity checks
 - inherit_context: true vs false behavior
+- Cross-scope argument provenance (should not leak)
 
 ## Reference Implementation
 
@@ -251,6 +343,12 @@ To be developed.
 3. **Result visibility?** Can outer PTB reference inner scope Results by index?
 4. **Error semantics?** Does inner scope failure abort entire PTB? (suggest yes - atomic)
 5. **Type interpolation interaction?** Should `typeFromResult` work across scope boundaries?
+6. **Argument indexing?** Should `&TxContext` count as arg 0, or be excluded from indexing?
+7. **Nested result granularity?** Should `argument_source` distinguish between tuple elements?
+
+## Related SIPs
+
+- PTB Type Argument Interpolation (enables `typeFromResult` for publish-and-use)
 
 ## Copyright
 

--- a/sips/sip-ptb_command_context.md
+++ b/sips/sip-ptb_command_context.md
@@ -1,7 +1,7 @@
 |   SIP-Number | |
 |         ---: | :--- |
 |        Title | PTB Command Context & Scoped Execution |
-|  Description | Expose PTB command history and argument provenance to Move, enabling dynamic dispatch and isolated scopes |
+|  Description | Expose PTB command metadata and argument provenance to Move; add scoped execution for isolation |
 |       Author | Greshamscode, @92GC |
 |       Editor | |
 |         Type | Standard |
@@ -12,91 +12,35 @@
 
 ## Abstract
 
-Four related enhancements to PTBs:
-1. **Command Context** - Expose previous command info (package, module, function) to Move
-2. **Argument Provenance** - Track which command produced each argument passed to a function
-3. **Scoped Execution** - Isolate groups of commands that share internal context but not external
-4. **Scope Witness** - Cryptographic proof that commands belong to same scope
+Four additions to PTBs:
+1. **Command Context** — Any command in a scope can read metadata (package, module, function) of every other command in that scope.
+2. **Argument Provenance** — Track which command produced each argument, enabling origin verification.
+3. **Scoped Execution** — Partition PTB commands into isolated groups that share internal context but hide it from the outside.
+4. **Scope Witness** — Proof that two commands executed in the same scope.
 
 ## Motivation
 
-### The Hot Potato Problem
+Composing Move protocols today requires hot potato wrappers for every integration. A DAO executing "vault spend → DEX swap → vault deposit" needs a custom wrapper action for each DEX. New DEX = new wrapper code.
 
-Today, composing Move protocols requires **application-level hot potatoes** - wrapper actions that must be pre-built for every external protocol integration.
-
-Example: A DAO wants to execute "spend USDC → swap on Cetus → deposit result":
-
-```
-Current approach:
-  Intent stages: [VaultSpend → CetusSwapWrapper → VaultDeposit]
-                              ↑
-                    Must pre-build this action
-                    Type-checks coin flow at compile time
-                    New protocol = new wrapper
-```
-
-This creates:
-- **Action explosion** - Every protocol integration needs custom wrapper code
-- **Upgrade burden** - Protocol upgrades require action updates
-- **Reduced composability** - Can't use protocols without pre-built wrappers
-
-### Dynamic Dispatch: The Solution
-
-With PTB Command Context + Argument Provenance, DAOs can verify constraints at runtime:
-
-```
-New approach:
-  Intent stages: [VaultSpend → <any approved protocol> → VaultDeposit]
-                              ↑
-                    No wrapper needed!
-                    Runtime verification via ptb_context
-```
-
-The deposit action verifies:
-1. "The coin I'm receiving came from command N" (argument provenance)
-2. "Command N was a call to an approved package" (command context)
+With command context + argument provenance, the deposit function can verify at runtime that the coin it received came from an approved package — no wrapper needed:
 
 ```move
-public fun deposit_from_approved_source<CoinType>(
-    ctx: &TxContext,
-    coin: Coin<CoinType>,
-) {
-    // Verify coin came from a PTB Result (not raw Input)
-    let source_idx = ptb_context::argument_source(ctx, 1); // arg 1 = coin
-    assert!(source_idx.is_some(), ENotFromPTBResult);
-
-    // Verify source command was approved protocol
-    let source_cmd = ptb_context::command_at(ctx, *source_idx.borrow());
-    assert!(is_approved_defi_protocol(source_cmd.package_id), EUnauthorizedSource);
-
-    // Proceed with deposit...
+public fun deposit_from_approved<CoinType>(ctx: &TxContext, coin: Coin<CoinType>) {
+    let source = ptb_context::argument_source(ctx, 0);
+    assert!(source.is_some(), ENotFromPTBResult);
+    let cmd = ptb_context::command_at(ctx, source.borrow().command_index());
+    assert!(is_approved(cmd.package_id), EUnauthorizedSource);
 }
 ```
 
-**Result**: No more wrapper actions. Integrate any protocol by adding it to an approved list.
-
-### Secondary Benefits
-
-**Scoped Execution** prevents protocol censorship:
-
-Without scopes, protocols could inspect PTB context and refuse to execute:
-```move
-// Malicious AMM could refuse arbitrage:
-if (is_competing_amm(previous_command(ctx))) abort ENoArbitrageAllowed;
-```
-
-Scopes hide context between isolated groups of commands, preserving:
-- Atomic execution (all-or-nothing)
-- Free composability (any protocol combination)
-- MEV resistance (patterns hidden from contracts)
+Scopes solve the flipside: without them, a protocol could inspect context and refuse execution when it sees a competitor in the same PTB. Scopes partition commands so each group only sees its own context, preventing censorship while keeping the transaction atomic.
 
 ## Specification
 
-### Part 1: Command Context
+### 1. Command Context
 
 ```move
 module sui::ptb_context {
-    /// Command types in PTB - defined as enum for type safety
     public enum CommandType has copy, drop {
         MoveCall,
         TransferObjects,
@@ -111,102 +55,75 @@ module sui::ptb_context {
     public struct CommandInfo has copy, drop {
         index: u16,
         command_type: CommandType,
-        package_id: address,    // MoveCall/Upgrade only, @0x0 for others
-        module_name: String,    // MoveCall only, empty for others
-        function_name: String,  // MoveCall only, empty for others
+        package_id: address,    // MoveCall/Upgrade only, @0x0 otherwise
+        module_name: String,    // MoveCall only
+        function_name: String,  // MoveCall only
     }
 
-    /// Current command's index in PTB (or scope)
+    /// Current command's index in its scope
     public native fun current_index(ctx: &TxContext): u16;
 
     /// Total commands in current scope
     public native fun total_commands(ctx: &TxContext): u16;
 
-    /// Get command info at index (must be < current_index, past only)
+    /// Get info for any command in the current scope
     public native fun command_at(ctx: &TxContext, index: u16): Option<CommandInfo>;
 
-    /// Convenience: previous command
-    public fun previous_command(ctx: &TxContext): Option<CommandInfo> {
-        let idx = current_index(ctx);
-        if (idx == 0) option::none()
-        else command_at(ctx, idx - 1)
-    }
-
-    /// Scope nesting depth (1 = top-level PTB or explicit scope, increments for nested)
-    /// NOTE: Top-level PTB is indistinguishable from explicit scope - both return 1
-    /// This prevents contracts from detecting whether caller used Scope command
+    /// Scope nesting depth. Top-level PTB and explicit scope both return 1
+    /// (indistinguishable by design — prevents contracts from detecting scope usage)
     public native fun scope_depth(ctx: &TxContext): u8;
 }
 ```
 
-### Part 2: Argument Provenance
+All commands within a scope can see all other commands in that scope. Visibility does not cross scope boundaries unless `inherit_context` is set.
+
+### 2. Argument Provenance
 
 ```move
 module sui::ptb_context {
-    /// Argument source types
     public enum ArgumentSource has copy, drop {
-        /// Value came from transaction Input (provided by sender)
         Input { input_index: u16 },
-        /// Value came from a previous command's Result
         Result { command_index: u16, result_index: u16 },
-        /// Value came from nested Result (e.g., Result(5, 0) for first return of command 5)
         NestedResult { command_index: u16, result_index: u16 },
     }
 
-    /// Get the source of argument at given index for current command
-    /// arg_index 0 = first argument (excluding &TxContext which is implicit)
-    /// Returns None if argument tracking unavailable
+    /// Source of the argument at the given index (excluding implicit &TxContext)
     public native fun argument_source(ctx: &TxContext, arg_index: u8): Option<ArgumentSource>;
 
-    /// Convenience: check if argument came from a specific command's result
+    /// Check if argument came from a specific command
     public fun argument_is_from_command(ctx: &TxContext, arg_index: u8, command_index: u16): bool {
         let source = argument_source(ctx, arg_index);
         if (source.is_none()) return false;
-
         match (*source.borrow()) {
             ArgumentSource::Result { command_index: idx, .. } => idx == command_index,
             ArgumentSource::NestedResult { command_index: idx, .. } => idx == command_index,
             _ => false,
         }
     }
-
-    /// Convenience: get command index that produced this argument (if Result-based)
-    public fun argument_command_index(ctx: &TxContext, arg_index: u8): Option<u16> {
-        let source = argument_source(ctx, arg_index);
-        if (source.is_none()) return option::none();
-
-        match (*source.borrow()) {
-            ArgumentSource::Result { command_index, .. } => option::some(command_index),
-            ArgumentSource::NestedResult { command_index, .. } => option::some(command_index),
-            _ => option::none(),
-        }
-    }
 }
 ```
 
-### Part 3: Scoped Execution
+### 3. Scoped Execution
 
-New `Command` variant:
+New PTB command variant:
 
 ```rust
 enum Command {
-    // ... existing ...
+    // ... existing variants ...
     Scope {
         commands: Vec<Command>,
-        inherit_context: bool,  // Can inner see outer command history?
+        inherit_context: bool,
     },
 }
 ```
 
-**Semantics:**
-- Commands inside scope share internal context
-- `current_index()` resets to 0 inside scope
-- `command_at()` only returns scope-internal commands (unless `inherit_context`)
-- `argument_source()` returns indices relative to current scope
-- Results can flow out via normal `Result(scope_idx)` references
-- Scopes can nest (scope_depth increments)
+- `current_index()` resets to 0 inside a scope
+- `command_at()` returns only scope-internal commands (unless `inherit_context: true`)
+- Argument provenance indices are scope-relative
+- Results flow out via normal `Result(scope_idx)` references
+- Scopes nest; `scope_depth` increments accordingly
 
-**SDK:**
+SDK usage:
 ```typescript
 ptb.scope({ inheritContext: false }, (scope) => {
     const pub = scope.publish({ modules, deps });
@@ -214,141 +131,62 @@ ptb.scope({ inheritContext: false }, (scope) => {
 });
 ```
 
-### Part 4: Scope Witness
+### 4. Scope Witness
 
 ```move
 module sui::ptb_context {
-    /// Witness proving commands are in same scope
     public struct ScopeWitness has drop {
         scope_id: u256,
         creator_index: u16,
         scope_depth: u8,
     }
 
-    /// Create witness (marks current command as scope anchor)
     public native fun create_scope_witness(ctx: &mut TxContext): ScopeWitness;
-
-    /// Verify caller is in same scope as witness creator
     public native fun in_same_scope(ctx: &TxContext, witness: &ScopeWitness): bool;
-
-    /// Get scope_id of current scope (unique per scope instance)
     public native fun current_scope_id(ctx: &TxContext): u256;
 }
 ```
 
 ## Rationale
 
-**Why expose command history?**
-- Enables trustless verification of caller identity
-- No opt-in required (unlike hot potato patterns)
-- Read-only - cannot enforce ordering, just verify
+**Full scope visibility (not past-only):** Restricting to past commands would still allow ordering games. Full visibility within a scope is simpler and lets contracts verify the complete execution context they're part of. Scopes are the isolation boundary, not command ordering.
 
-**Why argument provenance?**
-- Completes the verification story: know WHAT called you AND WHERE values came from
-- Enables "accept coin only if it came from approved protocol" pattern
-- Type safety preserved by Move's type system; provenance adds origin verification
+**Scopes, not `is_scoped()`:** Exposing whether a call is scoped would let protocols refuse non-scoped calls, defeating the purpose. `scope_depth()` returns 1 for both top-level and explicit scopes — indistinguishable.
 
-**Why scopes?**
-- Publish-and-use requires isolation (new types shouldn't leak)
-- Composability with boundaries (protocol A calls protocol B without exposing internals)
-- **Prevent AMM/protocol censorship** - contracts can't refuse execution based on surrounding PTB context
-- **Preserve global liquidity** - AMMs remain freely composable for arbitrage
-- **MEV resistance** - arbitrage patterns hidden from contracts (validators still see, but can't selectively abort)
-- Gas accounting per scope (future: parallel execution hints)
+**No parameter exposure:** Too expensive (arbitrary BCS), type-unsafe, and argument provenance covers the important cases.
 
-**Why not expose future commands?**
-- Would allow contracts to enforce specific PTB structure
-- Breaks composability (can't add cleanup commands after)
-- Creates ordering games between protocols
-
-**Why not expose parameters?**
-- Too expensive (arbitrary BCS data)
-- Type safety issues (how to represent in Move?)
-- Security risk (parameter inspection enables new attack vectors)
-- Argument provenance provides sufficient information for most use cases
-
-**Why not expose `is_scoped()`?**
-- Would allow contracts to detect if caller used Scope command
-- Defeats isolation purpose - protocols could refuse non-scoped calls
-- Instead, `scope_depth()` returns 1 for both top-level PTB and explicit scope
-
-**Alternatives rejected:**
-- Full call stack introspection - too invasive, breaks function isolation assumptions
-- Mutable context - allows state smuggling between commands
+**Exposure vs hiding is intentional:** Context lets governance protocols verify callers. Scopes let DeFi protocols stay composable. The user picks the boundary per call.
 
 ## Backwards Compatibility
 
-Purely additive:
-- New native functions in `sui::ptb_context`
-- New `Scope` command variant
-- Existing PTBs work unchanged
-- `ptb_context` functions return sensible defaults for non-scoped execution
-- `argument_source` returns `None` for commands executed before this feature
+Purely additive. Existing PTBs work unchanged. `ptb_context` functions return sensible defaults pre-feature. `argument_source` returns `None` for pre-feature commands.
 
 ## Security Considerations
 
-**Command Context:**
-- Read-only - cannot modify history
-- Only past commands visible (not future)
-- Package ID is immutable (Original ID, not upgraded address)
+- Read-only — commands can inspect context but not modify it
+- All commands in a scope see each other; scopes are the privacy boundary
+- Package IDs are Original IDs (immutable, not upgraded addresses)
+- Provenance is VM-tracked and unforgeable
+- Scope witnesses are VM-generated — cannot be spoofed
+- Max scope depth limit prevents gas exhaustion via deep nesting
+- Contracts should validate values, not just their provenance
 
-**Argument Provenance:**
-- Read-only tracking of PTB execution flow
-- Cannot forge provenance (VM-tracked)
-- Useful for allowlist-based verification, not for preventing all attacks
-- Contracts should still validate values themselves, not just their source
+## Open Questions
 
-**Scopes:**
-- Inner scope cannot access outer scope's Results unless explicitly passed
-- `inherit_context: false` provides strict isolation
-- Scope witness cannot be forged (VM-generated scope_id)
-- Argument provenance indices are scope-relative (cannot reference out-of-scope commands)
-
-**Attack vectors to consider:**
-- Scope escape via object references (mitigated: objects still owned normally)
-- Context spoofing (mitigated: native functions, not user-controllable)
-- Gas exhaustion via deep nesting (mitigated: max scope depth limit)
-- Provenance-based allowlist bypass (mitigated: contracts should validate values, not just source)
-
-**Design tension: Exposure vs Hiding**
-
-Parts 1-2 (Context + Provenance) and Part 3 (Scopes) create intentional tension:
-- Context exposure enables verifiable dispatch (good for governance, security)
-- Scopes enable context hiding (good for composability/MEV resistance)
-
-Resolution: **User controls the boundary**
-- Protocols that WANT caller verification use Parts 1-2 (governance, vaults, DAOs)
-- Protocols that SHOULD NOT discriminate are called within scopes (AMMs, orderbooks)
-- User decides isolation level per-call via `inheritContext` flag
+1. Max scope depth? (suggest 64)
+2. Should scopes have independent gas budgets?
+3. Can outer PTB reference inner scope Results by index?
+4. Does inner scope failure abort the entire PTB? (suggest yes)
+5. Should `typeFromResult` work across scope boundaries?
+6. Should `&TxContext` count as arg 0 or be excluded from indexing?
 
 ## Test Cases
 
-To be developed:
-- Command history accuracy across command types
-- Argument provenance tracking for all argument sources (Input, Result, NestedResult)
-- Scope isolation verification
-- Nested scope behavior
-- Scope witness validity checks
-- inherit_context: true vs false behavior
-- Cross-scope argument provenance (should not leak)
+To be developed.
 
 ## Reference Implementation
 
 To be developed.
-
-## Open Questions
-
-1. **Max scope depth?** Suggest 64 (sufficient for most use cases, limits complexity)
-2. **Scope gas limits?** Should scopes have independent gas budgets?
-3. **Result visibility?** Can outer PTB reference inner scope Results by index?
-4. **Error semantics?** Does inner scope failure abort entire PTB? (suggest yes - atomic)
-5. **Type interpolation interaction?** Should `typeFromResult` work across scope boundaries?
-6. **Argument indexing?** Should `&TxContext` count as arg 0, or be excluded from indexing?
-7. **Nested result granularity?** Should `argument_source` distinguish between tuple elements?
-
-## Related SIPs
-
-- PTB Type Argument Interpolation (enables `typeFromResult` for publish-and-use)
 
 ## Copyright
 


### PR DESCRIPTION
Add one native function on `sui::tx_context`:

```move
public fun current_command_range_hash(ctx: &TxContext, additional_commands: u64): vector<u8>
```

This returns a versioned hash of a given sequential range of the current PTB commands.

This let's a contract lock in the part of a PTB it cares about,
while leaving the rest of the PTB open for wallets, solvers, sponsors, or other
composition.

This is more useful than a whole-PTB hash for smart accounts and governance,
because the authorized intent can be fixed without forcing the whole transaction
to be fixed.